### PR TITLE
fix(windows): bundle d2.exe v0.7.1 for ER Diagram rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,10 @@ windows/Releases/
 windows/vendor/webview2/
 !windows/vendor/velopack/lib/velopack_libc_win_x64_msvc.lib
 
+# Bundled D2 CLI (Assets/d2/d2.exe) — ER Diagram uses it to render SVGs.
+# Binary is vendored so clones build + package without a manual download.
+!windows/Gridex/Assets/d2/d2.exe
+
 # Generated version header — written by build-unpackaged.ps1 -Version
 # from the CI tag, falls back to 0.0.0-dev locally via __has_include.
 windows/Gridex/GridexVersion.generated.h


### PR DESCRIPTION
ER Diagram feature shells out to Assets/d2/d2.exe to render the schema into SVG. Previously only LICENSE + README.txt lived in Assets/d2/, so the 0.0.5 installer shipped without the binary and users saw:

  Failed: d2.exe not found. Place it in Assets\d2\d2.exe.

Vendor the D2 CLI (Windows amd64, 48 MB) next to its existing LICENSE and override the repo-wide *.exe ignore for that single path so future builds + packages pick it up automatically.