### PR TITLE
feat(windows): grid UX improvements — context menu, toolbar, column metadata

### DIFF
--- a/windows/Gridex/DataGridView.cpp
+++ b/windows/Gridex/DataGridView.cpp
@@ -58,6 +58,47 @@ namespace winrt::Gridex::implementation
         {
             Grid_KeyDown(sender, e);
         });
+
+        // Right-click context menu. Host wires OnRefreshRequested /
+        // OnDeleteRequested in WorkspacePage; unset = no-op. Delete is
+        // disabled for read-only grids (e.g. Redis projections) and when
+        // no row is selected.
+        {
+            muxc::MenuFlyout contextMenu;
+
+            muxc::MenuFlyoutItem refreshItem;
+            refreshItem.Text(L"Refresh");
+            muxc::FontIcon refreshIcon;
+            refreshIcon.Glyph(L"\xE72C");
+            refreshItem.Icon(refreshIcon);
+            refreshItem.Click([this](auto&&, auto&&)
+            {
+                if (OnRefreshRequested) OnRefreshRequested();
+            });
+            contextMenu.Items().Append(refreshItem);
+
+            contextMenu.Items().Append(muxc::MenuFlyoutSeparator{});
+
+            muxc::MenuFlyoutItem deleteItem;
+            deleteItem.Text(L"Delete Row");
+            muxc::FontIcon deleteIcon;
+            deleteIcon.Glyph(L"\xE74D");
+            deleteItem.Icon(deleteIcon);
+            deleteItem.Click([this](auto&&, auto&&)
+            {
+                if (OnDeleteRequested) OnDeleteRequested();
+            });
+            contextMenu.Items().Append(deleteItem);
+
+            // Gate Delete on read-only mode + row selection at open time so
+            // the menu reflects the grid's actual state each right-click.
+            contextMenu.Opening([this, deleteItem](auto&&, auto&&)
+            {
+                deleteItem.IsEnabled(!readOnly_ && selectedRow_ >= 0);
+            });
+
+            this->ContextFlyout(contextMenu);
+        }
         this->Loaded([this](winrt::Windows::Foundation::IInspectable const&, mux::RoutedEventArgs const&)
         {
             DataScroller().ViewChanged(

--- a/windows/Gridex/DataGridView.cpp
+++ b/windows/Gridex/DataGridView.cpp
@@ -139,6 +139,15 @@ namespace winrt::Gridex::implementation
         });
     }
 
+    void DataGridView::SetColumnMetadata(const std::vector<DBModels::ColumnInfo>& meta)
+    {
+        columnMetadata_ = meta;
+        // Re-render headers only if we already have data laid out;
+        // otherwise the next SetData call will pick up the metadata.
+        if (!data_.columnNames.empty())
+            BuildHeaders();
+    }
+
     void DataGridView::SetData(const DBModels::QueryResult& result)
     {
         data_        = result;
@@ -264,43 +273,96 @@ namespace winrt::Gridex::implementation
             headerBtn.BorderThickness(mux::Thickness{ 0, 0, 0, 0 });
             muxc::Grid::SetColumn(headerBtn, 0);
 
-            // Header content layout: Grid with [auto icon] [* label] [auto sort].
-            // Star column on the label means it auto-stretches to whatever
-            // space is left after the icons — when the user resizes the
-            // outer cellGrid, the label's available width tracks live via
-            // layout pass, no manual MaxWidth bookkeeping needed.
+            // Look up optional metadata (PK / FK / nullable / full type
+            // string) by column name. Header falls back gracefully if
+            // SetColumnMetadata was never called (e.g., ad-hoc query view).
+            const DBModels::ColumnInfo* meta = nullptr;
+            for (const auto& m : columnMetadata_)
+            {
+                if (m.name == colName) { meta = &m; break; }
+            }
+
+            // Resolve type string: prefer metadata (has length info like
+            // varchar(255)), else QueryResult.columnTypes.
+            std::wstring colType;
+            if (meta && !meta->dataType.empty()) colType = meta->dataType;
+            else if (ci < data_.columnTypes.size()) colType = data_.columnTypes[ci];
+
+            // Header content layout: Grid with [auto PK] [auto FK] [* label]
+            // [auto sort]. Star column on the label lets it auto-stretch to
+            // whatever space is left after the icons — when the user resizes
+            // the outer cellGrid, the label's available width tracks live
+            // via layout pass, no manual MaxWidth bookkeeping needed.
             muxc::Grid headerContent;
             {
-                muxc::ColumnDefinition iconCol, labelCol, sortCol;
-                iconCol.Width(mux::GridLength{ 0.0, mux::GridUnitType::Auto });
+                muxc::ColumnDefinition pkCol, fkCol, labelCol, sortCol;
+                pkCol.Width(mux::GridLength{ 0.0, mux::GridUnitType::Auto });
+                fkCol.Width(mux::GridLength{ 0.0, mux::GridUnitType::Auto });
                 labelCol.Width(mux::GridLength{ 1.0, mux::GridUnitType::Star });
                 sortCol.Width(mux::GridLength{ 0.0, mux::GridUnitType::Auto });
-                headerContent.ColumnDefinitions().Append(iconCol);
+                headerContent.ColumnDefinitions().Append(pkCol);
+                headerContent.ColumnDefinitions().Append(fkCol);
                 headerContent.ColumnDefinitions().Append(labelCol);
                 headerContent.ColumnDefinitions().Append(sortCol);
             }
 
-            // Column type icon at column 0
-            std::wstring colType;
-            if (ci < data_.columnTypes.size()) colType = data_.columnTypes[ci];
-            muxc::FontIcon typeIcon;
-            typeIcon.FontSize(10.0);
-            typeIcon.Opacity(0.4);
-            typeIcon.Margin(mux::Thickness{ 0.0, 0.0, 4.0, 0.0 });
-            if (colType.find(L"int") != std::wstring::npos || colType.find(L"numeric") != std::wstring::npos)
-                typeIcon.Glyph(L"\xE8EF");
-            else if (colType.find(L"bool") != std::wstring::npos)
-                typeIcon.Glyph(L"\xE73E");
-            else if (colType.find(L"time") != std::wstring::npos || colType.find(L"date") != std::wstring::npos)
-                typeIcon.Glyph(L"\xE787");
-            else
-                typeIcon.Glyph(L"\xE8C1");
-            muxc::Grid::SetColumn(typeIcon, 0);
-            headerContent.Children().Append(typeIcon);
+            // PK icon (key glyph) — gold-ish tint so it reads as a badge.
+            if (meta && meta->isPrimaryKey)
+            {
+                muxc::FontIcon pkIcon;
+                pkIcon.Glyph(L"\xE192");
+                pkIcon.FontSize(10.0);
+                pkIcon.Margin(mux::Thickness{ 0.0, 0.0, 4.0, 0.0 });
+                pkIcon.Foreground(muxm::SolidColorBrush(
+                    winrt::Windows::UI::ColorHelper::FromArgb(255, 220, 170, 40)));
+                muxc::ToolTip pkTip;
+                pkTip.Content(winrt::box_value(winrt::hstring(L"Primary Key")));
+                muxc::ToolTipService::SetToolTip(pkIcon, pkTip);
+                muxc::Grid::SetColumn(pkIcon, 0);
+                headerContent.Children().Append(pkIcon);
+            }
 
-            // Label at column 1 — fills the star column. NO MaxWidth — the
+            // FK icon (link glyph). Wrap in a button so the click jumps
+            // to the referenced table — separate from header sort click.
+            if (meta && meta->isForeignKey)
+            {
+                muxc::Button fkBtn;
+                fkBtn.Padding(mux::Thickness{ 2.0, 0.0, 2.0, 0.0 });
+                fkBtn.Margin(mux::Thickness{ 0.0, 0.0, 4.0, 0.0 });
+                fkBtn.Background(muxm::SolidColorBrush(winrt::Windows::UI::Colors::Transparent()));
+                fkBtn.BorderThickness(mux::Thickness{ 0, 0, 0, 0 });
+                fkBtn.MinWidth(0.0);
+                fkBtn.MinHeight(0.0);
+                muxc::FontIcon fkIcon;
+                fkIcon.Glyph(L"\xE71B");
+                fkIcon.FontSize(10.0);
+                fkIcon.Foreground(muxm::SolidColorBrush(
+                    winrt::Windows::UI::ColorHelper::FromArgb(255, 88, 166, 255)));
+                fkBtn.Content(fkIcon);
+
+                std::wstring refTable  = meta->fkReferencedTable;
+                std::wstring refColumn = meta->fkReferencedColumn;
+                std::wstring fkTipText = L"Foreign Key → " + refTable;
+                if (!refColumn.empty()) fkTipText += L"." + refColumn;
+                fkTipText += L"\n(click to open referenced table)";
+                muxc::ToolTip fkTip;
+                fkTip.Content(winrt::box_value(winrt::hstring(fkTipText)));
+                muxc::ToolTipService::SetToolTip(fkBtn, fkTip);
+
+                fkBtn.Click([this, refTable](auto&&, auto&&)
+                {
+                    if (OnForeignKeyClicked && !refTable.empty())
+                        OnForeignKeyClicked(refTable, L"");
+                });
+                muxc::Grid::SetColumn(fkBtn, 1);
+                headerContent.Children().Append(fkBtn);
+            }
+
+            // Label at column 2 — fills the star column. NO MaxWidth — the
             // grid layout constrains it; trimming kicks in only when the
-            // column is actually narrower than the text.
+            // column is actually narrower than the text. Nullable columns
+            // render in italics so the distinction is obvious at a glance
+            // without stealing extra header space for a separate indicator.
             muxc::TextBlock lbl;
             lbl.Text(winrt::hstring(colName));
             lbl.FontSize(11.0);
@@ -308,10 +370,40 @@ namespace winrt::Gridex::implementation
             lbl.VerticalAlignment(mux::VerticalAlignment::Center);
             lbl.TextTrimming(mux::TextTrimming::CharacterEllipsis);
             lbl.TextWrapping(mux::TextWrapping::NoWrap);
-            muxc::Grid::SetColumn(lbl, 1);
+            if (meta && meta->nullable)
+                lbl.FontStyle(winrt::Windows::UI::Text::FontStyle::Italic);
+            muxc::Grid::SetColumn(lbl, 2);
             headerContent.Children().Append(lbl);
 
-            // Sort indicator at column 2 (only if this column is the sort key)
+            // Tooltip on the whole header button summarising every piece
+            // of metadata we have — the spot users reach for when the
+            // column's declared type or constraints are not obvious.
+            {
+                std::wstring tipText;
+                if (!colType.empty()) tipText = colType;
+                if (meta)
+                {
+                    tipText += tipText.empty() ? L"" : L"\n";
+                    tipText += meta->nullable ? L"NULL" : L"NOT NULL";
+                    if (meta->isPrimaryKey) tipText += L"\nPRIMARY KEY";
+                    if (meta->isForeignKey)
+                    {
+                        tipText += L"\nFK → " + meta->fkReferencedTable;
+                        if (!meta->fkReferencedColumn.empty())
+                            tipText += L"." + meta->fkReferencedColumn;
+                    }
+                    if (!meta->defaultValue.empty())
+                        tipText += L"\nDEFAULT " + meta->defaultValue;
+                }
+                if (!tipText.empty())
+                {
+                    muxc::ToolTip headerTip;
+                    headerTip.Content(winrt::box_value(winrt::hstring(tipText)));
+                    muxc::ToolTipService::SetToolTip(headerBtn, headerTip);
+                }
+            }
+
+            // Sort indicator at column 3 (only if this column is the sort key)
             if (sortColumn_ == colName)
             {
                 muxc::FontIcon sortIcon;
@@ -319,7 +411,7 @@ namespace winrt::Gridex::implementation
                 sortIcon.Glyph(sortAscending_ ? L"\xE70E" : L"\xE70D");
                 sortIcon.Opacity(0.7);
                 sortIcon.Margin(mux::Thickness{ 4.0, 0.0, 0.0, 0.0 });
-                muxc::Grid::SetColumn(sortIcon, 2);
+                muxc::Grid::SetColumn(sortIcon, 3);
                 headerContent.Children().Append(sortIcon);
             }
 

--- a/windows/Gridex/DataGridView.h
+++ b/windows/Gridex/DataGridView.h
@@ -33,6 +33,10 @@ namespace winrt::Gridex::implementation
         // deleted (pending commit). Host routes this to DeleteSelectedRow.
         std::function<void()> OnDeleteRequested;
 
+        // Callback when user picks "Refresh" from the grid context menu —
+        // host re-runs the current tab's query to pull fresh rows.
+        std::function<void()> OnRefreshRequested;
+
         // Get selected row data for copy
         const DBModels::TableRow* GetSelectedRow() const;
 

--- a/windows/Gridex/DataGridView.h
+++ b/windows/Gridex/DataGridView.h
@@ -2,6 +2,7 @@
 
 #include "DataGridView.g.h"
 #include "Models/QueryResult.h"
+#include "Models/ColumnInfo.h"
 #include <functional>
 
 namespace winrt::Gridex::implementation
@@ -11,6 +12,13 @@ namespace winrt::Gridex::implementation
         DataGridView();
 
         void SetData(const DBModels::QueryResult& result);
+
+        // Optional: feed full column metadata (PK / FK / nullable / full
+        // dataType string) so the header can render PK / FK icons, a
+        // tooltip with the declared type, and italicize nullable columns.
+        // Safe to omit — SetData alone still works with types from
+        // QueryResult.columnTypes but without PK/FK/nullable decoration.
+        void SetColumnMetadata(const std::vector<DBModels::ColumnInfo>& meta);
 
         // Put the grid in read-only mode (disables inline cell editing).
         // Used for adapters like Redis where the "table" is a key/value
@@ -37,6 +45,12 @@ namespace winrt::Gridex::implementation
         // host re-runs the current tab's query to pull fresh rows.
         std::function<void()> OnRefreshRequested;
 
+        // Callback when user clicks an FK icon in a column header — host
+        // navigates to the referenced table/schema. Arg schema may be
+        // empty; host falls back to the current connection's default.
+        std::function<void(const std::wstring& refTable,
+                           const std::wstring& refSchema)> OnForeignKeyClicked;
+
         // Get selected row data for copy
         const DBModels::TableRow* GetSelectedRow() const;
 
@@ -59,6 +73,7 @@ namespace winrt::Gridex::implementation
 
     private:
         DBModels::QueryResult data_;
+        std::vector<DBModels::ColumnInfo> columnMetadata_;
         int selectedRow_ = -1;
         std::wstring sortColumn_;
         bool sortAscending_ = true;

--- a/windows/Gridex/WorkspacePage.cpp
+++ b/windows/Gridex/WorkspacePage.cpp
@@ -173,6 +173,12 @@ namespace winrt::Gridex::implementation
             DeleteSelectedRow();
         };
 
+        // Right-click → Refresh: re-run the active tab's query.
+        DataGrid().as<DataGridView>()->OnRefreshRequested = [this]()
+        {
+            ReloadCurrentTable();
+        };
+
         // Wire structure view ALTER apply
         Structure().as<StructureView>()->OnApplyAlter = [this](const std::vector<std::wstring>& sqls)
         {
@@ -760,17 +766,8 @@ namespace winrt::Gridex::implementation
         SidebarToggleBtn().Click([this](winrt::Windows::Foundation::IInspectable const&, mux::RoutedEventArgs const&)
         { ToggleSidebar_Click({}, {}); });
 
-        DeleteBtn().Click([this](winrt::Windows::Foundation::IInspectable const&, mux::RoutedEventArgs const&)
-        { DeleteSelectedRow(); });
-
-        CommitToolbarBtn().Click([this](winrt::Windows::Foundation::IInspectable const&, mux::RoutedEventArgs const&)
-        { CommitChanges(); });
-
         DetailsToggleBtn().Click([this](winrt::Windows::Foundation::IInspectable const&, mux::RoutedEventArgs const&)
         { ToggleDetails_Click({}, {}); });
-
-        AiToggleBtn().Click([this](winrt::Windows::Foundation::IInspectable const&, mux::RoutedEventArgs const&)
-        { ToggleAI_Click({}, {}); });
 
         DumpBtn().Click([this](winrt::Windows::Foundation::IInspectable const&, mux::RoutedEventArgs const&)
         { DumpDatabaseAsync(); });

--- a/windows/Gridex/WorkspacePage.cpp
+++ b/windows/Gridex/WorkspacePage.cpp
@@ -179,6 +179,16 @@ namespace winrt::Gridex::implementation
             ReloadCurrentTable();
         };
 
+        // FK icon click in a header → open the referenced table. Schema
+        // arg is empty; reuse the current schema so cross-schema FKs in
+        // pg still resolve against the active search path.
+        DataGrid().as<DataGridView>()->OnForeignKeyClicked =
+            [this](const std::wstring& refTable, const std::wstring&)
+        {
+            if (!refTable.empty())
+                OnTableSelected(refTable, currentSchema_);
+        };
+
         // Wire structure view ALTER apply
         Structure().as<StructureView>()->OnApplyAlter = [this](const std::vector<std::wstring>& sqls)
         {
@@ -1489,6 +1499,8 @@ namespace winrt::Gridex::implementation
                 // layer instead of lumped under a single number.
                 auto renderStart = std::chrono::steady_clock::now();
                 self->DataGrid().as<DataGridView>()->SetData(self->state_.currentData);
+                self->DataGrid().as<DataGridView>()->SetColumnMetadata(
+                    self->state_.currentColumns);
                 auto renderEnd = std::chrono::steady_clock::now();
                 self->state_.statusRenderTimeMs =
                     std::chrono::duration<double, std::milli>(renderEnd - renderStart).count();

--- a/windows/Gridex/WorkspacePage.xaml
+++ b/windows/Gridex/WorkspacePage.xaml
@@ -61,8 +61,9 @@
                            Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
             </StackPanel>
 
-            <!-- Right: Delete + Commit | Details + AI -->
+            <!-- Right toolbar, grouped: [Backup] | [Schema] | [App] -->
             <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="4">
+                <!-- Group 1: Backup / Restore -->
                 <Button x:Name="DumpBtn" Width="32" Height="32" Padding="0"
                         Background="Transparent" BorderThickness="0"
                         ToolTipService.ToolTip="Dump Database">
@@ -73,32 +74,25 @@
                         ToolTipService.ToolTip="Restore Database">
                     <FontIcon Glyph="&#xE777;" FontSize="14" />
                 </Button>
+
+                <Border Width="1" Height="20" Margin="4,0"
+                        Background="{ThemeResource DividerStrokeColorDefaultBrush}" />
+
+                <!-- Group 2: Schema visualization -->
                 <Button x:Name="ERDiagramBtn" Width="32" Height="32" Padding="0"
                         Background="Transparent" BorderThickness="0"
                         ToolTipService.ToolTip="ER Diagram (current schema)">
                     <FontIcon Glyph="&#xF169;" FontSize="14" />
                 </Button>
-                <Button x:Name="DeleteBtn" Width="32" Height="32" Padding="0"
-                        Background="Transparent" BorderThickness="0"
-                        ToolTipService.ToolTip="Delete Selected Rows">
-                    <FontIcon Glyph="&#xE74D;" FontSize="14" />
-                </Button>
-                <Button x:Name="CommitToolbarBtn" Width="32" Height="32" Padding="0"
-                        Background="Transparent" BorderThickness="0"
-                        ToolTipService.ToolTip="Commit Changes">
-                    <FontIcon Glyph="&#xE73E;" FontSize="14" />
-                </Button>
+
                 <Border Width="1" Height="20" Margin="4,0"
                         Background="{ThemeResource DividerStrokeColorDefaultBrush}" />
+
+                <!-- Group 3: UI toggles + app settings -->
                 <Button x:Name="DetailsToggleBtn" Width="32" Height="32" Padding="0"
                         Background="Transparent" BorderThickness="0"
                         ToolTipService.ToolTip="Toggle Details Panel">
                     <FontIcon Glyph="&#xE146;" FontSize="14" />
-                </Button>
-                <Button x:Name="AiToggleBtn" Width="32" Height="32" Padding="0"
-                        Background="Transparent" BorderThickness="0"
-                        ToolTipService.ToolTip="Toggle AI Assistant">
-                    <FontIcon Glyph="&#xE945;" FontSize="14" />
                 </Button>
                 <Button x:Name="SettingsBtn" Width="32" Height="32" Padding="0"
                         Background="Transparent" BorderThickness="0"


### PR DESCRIPTION
## Summary
Three UX improvements on the Windows app data grid:

### 1. Right-click context menu on DataGridView
- **Refresh** — re-pull active tab's rows
- **Delete Row** — mark selected row for deletion (disabled when read-only or no row selected)

### 2. Top-right toolbar cleanup
- Removed redundant buttons (**Delete**, **Commit**, **Toggle AI**) — all still accessible via Delete key / CommitBottomBtn / DetailsPanel Assistant tab
- Regrouped remaining buttons into 3 sections with dividers:
  - **[Dump] [Restore]** — backup
  - **[ER Diagram]** — schema
  - **[Details] [Settings]** — app
- Tooltips on every button (kept existing `ToolTipService.ToolTip`)

### 3. Column header metadata
- **PK icon** (gold key) for primary keys
- **FK icon** (blue link, **clickable** → jumps to referenced table) for foreign keys
- **Nullable columns** rendered in italics (clean visual without extra space)
- **Tooltip** on each header with full dataType, NULL/NOT NULL, PK, FK → ref.col, DEFAULT

## Files
- `windows/Gridex/DataGridView.cpp/h` — context menu, `SetColumnMetadata`, PK/FK icons, `OnForeignKeyClicked`
- `windows/Gridex/WorkspacePage.cpp` — wire right-click Delete/Refresh + FK click, feed column metadata to grid
- `windows/Gridex/WorkspacePage.xaml` — regrouped toolbar

## Test plan
- [ ] Right-click grid → Refresh / Delete Row work; Delete disabled when no row selected or read-only (Redis)
- [ ] Top-right toolbar shows 5 buttons in 3 groups with dividers
- [ ] Open a table with PK/FK columns → key icon on PK, link icon on FK columns
- [ ] Click FK icon → opens referenced table
- [ ] Hover header → tooltip shows type + NULL/NOT NULL + constraints
- [ ] Nullable columns render in italic, NOT NULL in normal weight
- [ ] Ad-hoc query results (no metadata) → headers render normally without crash