### PR TITLE
feat(windows): keyboard shortcuts reference + drop Ctrl+C row-copy

### DIFF
--- a/windows/Gridex/DataGridView.cpp
+++ b/windows/Gridex/DataGridView.cpp
@@ -935,26 +935,19 @@ namespace winrt::Gridex::implementation
             OnCellEdited(rowIndex, colName, oldValue, newValue);
     }
 
-    // ── Key shortcuts: Ctrl+C copy, Delete mark-deleted ───
+    // ── Key shortcuts: Delete mark-deleted ───
+    //
+    // Ctrl+C used to copy the whole row TSV, but it fought the natural
+    // cell-level copy users expect — selecting text inside a cell and
+    // hitting Ctrl+C was dumping every column instead of the selection.
+    // Row-copy stays available via CopySelectedRowToClipboard() for a
+    // future context-menu wiring; the hotkey itself is gone so the
+    // built-in TextBox Ctrl+C behaviour during inline edit wins.
     void DataGridView::Grid_KeyDown(
         winrt::Windows::Foundation::IInspectable const&,
         winrt::Microsoft::UI::Xaml::Input::KeyRoutedEventArgs const& e)
     {
         auto key = e.Key();
-
-        if (key == winrt::Windows::System::VirtualKey::C)
-        {
-            auto ctrlState = winrt::Microsoft::UI::Input::InputKeyboardSource::GetKeyStateForCurrentThread(
-                winrt::Windows::System::VirtualKey::Control);
-            bool ctrlDown = (static_cast<int>(ctrlState) &
-                static_cast<int>(winrt::Windows::UI::Core::CoreVirtualKeyStates::Down)) != 0;
-            if (ctrlDown)
-            {
-                CopySelectedRowToClipboard();
-                e.Handled(true);
-            }
-            return;
-        }
 
         // Delete key → mark selected row as deleted (pending commit).
         // No-op when read-only (e.g. Redis) or when nothing is selected.

--- a/windows/Gridex/Gridex.vcxproj
+++ b/windows/Gridex/Gridex.vcxproj
@@ -145,6 +145,7 @@
     <ClInclude Include="Models\SidebarItem.h" />
     <ClInclude Include="Models\ContentTab.h" />
     <ClInclude Include="Models\ColumnInfo.h" />
+    <ClInclude Include="Models\ShortcutsCatalog.h" />
     <ClInclude Include="Models\TableRow.h" />
     <ClInclude Include="Models\QueryResult.h" />
     <ClInclude Include="Models\WorkspaceState.h" />

--- a/windows/Gridex/MainWindow.xaml.cpp
+++ b/windows/Gridex/MainWindow.xaml.cpp
@@ -12,6 +12,7 @@
 #include "HomePage.h"
 #include "WorkspacePage.h"
 #include "Models/AppSettings.h"
+#include "Models/ShortcutsCatalog.h"
 #include "UpdateService.h"
 #include <winrt/Microsoft.UI.Dispatching.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
@@ -82,6 +83,32 @@ namespace winrt::Gridex::implementation
                     args.Handled(true);
                 });
                 content.KeyboardAccelerators().Append(homeAccel);
+
+                // Ctrl+/ → Keyboard Shortcuts dialog. Uses VK_OEM_2 (0xBF)
+                // for the main-keyboard "/" key; the named VirtualKey enum
+                // only covers Divide (numpad) which would miss the usual
+                // convention. F1 is also registered below as a fallback
+                // because some keyboard layouts remap Oem2 (e.g. German
+                // uses "-" on that key).
+                auto shortcutsAccel = mux::Input::KeyboardAccelerator();
+                shortcutsAccel.Key(static_cast<winrt::Windows::System::VirtualKey>(0xBF));
+                shortcutsAccel.Modifiers(winrt::Windows::System::VirtualKeyModifiers::Control);
+                shortcutsAccel.Invoked([this](auto&&, mux::Input::KeyboardAcceleratorInvokedEventArgs const& args)
+                {
+                    ShowShortcutsDialog();
+                    args.Handled(true);
+                });
+                content.KeyboardAccelerators().Append(shortcutsAccel);
+
+                // F1 → same dialog. Universal Help key, layout-safe fallback.
+                auto helpAccel = mux::Input::KeyboardAccelerator();
+                helpAccel.Key(winrt::Windows::System::VirtualKey::F1);
+                helpAccel.Invoked([this](auto&&, mux::Input::KeyboardAcceleratorInvokedEventArgs const& args)
+                {
+                    ShowShortcutsDialog();
+                    args.Handled(true);
+                });
+                content.KeyboardAccelerators().Append(helpAccel);
             }
 
             // Blocking update check BEFORE navigating to HomePage.
@@ -217,5 +244,45 @@ namespace winrt::Gridex::implementation
     {
         NavigateTo(L"Gridex.HomePage");
         args.Handled(true);
+    }
+
+    // Triggered by Ctrl+/ or F1 — shows a ContentDialog with the full
+    // list of hotkeys grouped by category. Markup is built entirely in
+    // code via DBModels::BuildShortcutsView() so the Settings page and
+    // this dialog render the same view from one source of truth.
+    void MainWindow::ShowShortcutsDialog()
+    {
+        auto content = this->Content().try_as<mux::FrameworkElement>();
+        if (!content) return;
+        auto xamlRoot = content.XamlRoot();
+        if (!xamlRoot) return;
+
+        mux::Controls::ContentDialog dlg;
+        dlg.Title(winrt::box_value(winrt::hstring(L"Keyboard Shortcuts")));
+        dlg.CloseButtonText(L"Close");
+        dlg.DefaultButton(mux::Controls::ContentDialogButton::Close);
+        dlg.XamlRoot(xamlRoot);
+
+        // Scroll wrapper — list may grow beyond the default dialog height
+        // as more shortcuts get registered. MaxHeight keeps the dialog
+        // itself constrained so it never spans the full window height.
+        mux::Controls::ScrollViewer scroller;
+        scroller.MaxHeight(520.0);
+        scroller.HorizontalScrollBarVisibility(mux::Controls::ScrollBarVisibility::Disabled);
+        scroller.VerticalScrollBarVisibility(mux::Controls::ScrollBarVisibility::Auto);
+        scroller.Content(DBModels::BuildShortcutsView());
+        dlg.Content(scroller);
+
+        // Widen the default 456px ContentDialog so the action label and
+        // key cap fit on one line without aggressive truncation.
+        dlg.Resources().Insert(
+            winrt::box_value(L"ContentDialogMaxWidth"),
+            winrt::box_value(640.0));
+        dlg.Resources().Insert(
+            winrt::box_value(L"ContentDialogMinWidth"),
+            winrt::box_value(520.0));
+
+        try { dlg.ShowAsync(); }
+        catch (...) { /* best effort; never block app on dialog failures */ }
     }
 }

--- a/windows/Gridex/MainWindow.xaml.h
+++ b/windows/Gridex/MainWindow.xaml.h
@@ -24,6 +24,7 @@ namespace winrt::Gridex::implementation
     private:
         void NavigateTo(const wchar_t* pageTypeName);
         void EnterAppAfterUpdateCheck();
+        void ShowShortcutsDialog();
     };
 }
 

--- a/windows/Gridex/Models/ShortcutsCatalog.h
+++ b/windows/Gridex/Models/ShortcutsCatalog.h
@@ -1,0 +1,129 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Microsoft.UI.Xaml.Media.h>
+#include <winrt/Windows.UI.h>
+#include <winrt/Windows.UI.Text.h>
+
+namespace DBModels
+{
+    // Single entry in the Keyboard Shortcuts reference. Keep this struct
+    // flat and Sendable — BuildShortcutsView() reads the list to render
+    // both the Ctrl+/ dialog and the Settings section (single source of
+    // truth, no risk of drift between the two surfaces).
+    struct ShortcutEntry
+    {
+        std::wstring category;   // "Global", "Data Grid", "Query Editor"
+        std::wstring action;     // "Commit changes"
+        std::wstring keys;       // "Ctrl+S"
+    };
+
+    // Full list. When adding a new hotkey in the app, also add it here so
+    // it shows up in the reference. Ordering within a category is the
+    // display order shown to the user.
+    inline std::vector<ShortcutEntry> GetAllShortcuts()
+    {
+        return {
+            // Global
+            { L"Global", L"Show this dialog",   L"Ctrl+/"       },
+            { L"Global", L"Settings",           L"Ctrl+Shift+P" },
+            { L"Global", L"Home",               L"Ctrl+H"       },
+
+            // Data Grid
+            { L"Data Grid", L"Commit changes",       L"Ctrl+S"     },
+            { L"Data Grid", L"Delete selected row",  L"Delete"     },
+            { L"Data Grid", L"Edit cell",            L"Enter"      },
+            { L"Data Grid", L"Cancel edit",          L"Esc"        },
+            { L"Data Grid", L"Horizontal scroll",    L"Shift+Wheel"},
+
+            // Query Editor
+            { L"Query Editor", L"Run query",     L"Ctrl+Enter" },
+            { L"Query Editor", L"Autocomplete",  L"Ctrl+Space" },
+            { L"Query Editor", L"Close popup",   L"Esc"        },
+        };
+    }
+
+    // Build a ready-to-embed view showing all shortcuts grouped by
+    // category. Used by both the Ctrl+/ ContentDialog and the Settings
+    // page so both stay visually identical without duplicated markup.
+    inline winrt::Microsoft::UI::Xaml::Controls::StackPanel BuildShortcutsView()
+    {
+        namespace mux  = winrt::Microsoft::UI::Xaml;
+        namespace muxc = winrt::Microsoft::UI::Xaml::Controls;
+        namespace muxm = winrt::Microsoft::UI::Xaml::Media;
+
+        muxc::StackPanel root;
+        root.Spacing(16.0);
+
+        const auto shortcuts = GetAllShortcuts();
+
+        // Walk the list in order, starting a new section every time the
+        // category changes. Relies on GetAllShortcuts() returning entries
+        // already grouped by category — simpler than a map and preserves
+        // the author-specified ordering within each group.
+        std::wstring lastCategory;
+        muxc::StackPanel currentSection{ nullptr };
+
+        for (const auto& s : shortcuts)
+        {
+            if (s.category != lastCategory)
+            {
+                lastCategory = s.category;
+
+                muxc::TextBlock header;
+                header.Text(winrt::hstring(s.category));
+                header.FontSize(11.0);
+                header.FontWeight(winrt::Windows::UI::Text::FontWeights::SemiBold());
+                header.Opacity(0.6);
+                header.Margin(mux::Thickness{ 0, 0, 0, 4 });
+                root.Children().Append(header);
+
+                currentSection = muxc::StackPanel{};
+                currentSection.Spacing(6.0);
+                root.Children().Append(currentSection);
+            }
+
+            // Row: action label (left, stretches) + key cap (right).
+            muxc::Grid row;
+            muxc::ColumnDefinition labelCol, keyCol;
+            labelCol.Width(mux::GridLength{ 1.0, mux::GridUnitType::Star });
+            keyCol.Width(mux::GridLength{ 0.0, mux::GridUnitType::Auto });
+            row.ColumnDefinitions().Append(labelCol);
+            row.ColumnDefinitions().Append(keyCol);
+
+            muxc::TextBlock action;
+            action.Text(winrt::hstring(s.action));
+            action.FontSize(13.0);
+            action.VerticalAlignment(mux::VerticalAlignment::Center);
+            muxc::Grid::SetColumn(action, 0);
+            row.Children().Append(action);
+
+            // Key cap: rounded rect with monospace text so "Ctrl+S" reads
+            // like a keyboard key and not a word in a sentence.
+            muxc::Border keyCap;
+            keyCap.Padding(mux::Thickness{ 8, 2, 8, 2 });
+            keyCap.CornerRadius(mux::CornerRadius{ 4, 4, 4, 4 });
+            keyCap.Background(muxm::SolidColorBrush(
+                winrt::Windows::UI::ColorHelper::FromArgb(40, 128, 128, 128)));
+            keyCap.BorderBrush(muxm::SolidColorBrush(
+                winrt::Windows::UI::ColorHelper::FromArgb(60, 128, 128, 128)));
+            keyCap.BorderThickness(mux::Thickness{ 1, 1, 1, 1 });
+
+            muxc::TextBlock keysText;
+            keysText.Text(winrt::hstring(s.keys));
+            keysText.FontSize(11.0);
+            keysText.FontFamily(muxm::FontFamily(L"Cascadia Code,Consolas,monospace"));
+            keysText.VerticalAlignment(mux::VerticalAlignment::Center);
+            keyCap.Child(keysText);
+
+            muxc::Grid::SetColumn(keyCap, 1);
+            row.Children().Append(keyCap);
+
+            if (currentSection) currentSection.Children().Append(row);
+        }
+
+        return root;
+    }
+}

--- a/windows/Gridex/SettingsPage.cpp
+++ b/windows/Gridex/SettingsPage.cpp
@@ -4,6 +4,7 @@
 #include <shellapi.h>
 #include "SettingsPage.h"
 #include "Models/AppSettings.h"
+#include "Models/ShortcutsCatalog.h"
 #include "GridexVersion.h"
 #include "UpdateService.h"
 #if __has_include("SettingsPage.g.cpp")
@@ -25,6 +26,11 @@ namespace winrt::Gridex::implementation
             // comes from GridexVersion.h which pulls the CI-generated header
             // when present (release builds) or falls back to "0.0.0-dev".
             VersionText().Text(winrt::hstring(L"Version " GRIDEX_VERSION));
+
+            // Populate the Keyboard Shortcuts section from the shared
+            // catalog — same builder feeds the Ctrl+/ dialog, so edits
+            // to ShortcutsCatalog.h propagate to both surfaces.
+            ShortcutsHost().Content(DBModels::BuildShortcutsView());
 
             // Load persisted settings into UI
             auto s = DBModels::AppSettings::Load();

--- a/windows/Gridex/SettingsPage.xaml
+++ b/windows/Gridex/SettingsPage.xaml
@@ -179,6 +179,27 @@
                 </Grid>
             </StackPanel>
 
+            <!-- Keyboard Shortcuts — populated in SettingsPage.cpp from
+                 DBModels::BuildShortcutsView() so this section and the
+                 Ctrl+/ dialog stay visually identical. -->
+            <StackPanel Spacing="12">
+                <TextBlock Text="Keyboard Shortcuts" FontSize="16" FontWeight="SemiBold" />
+                <Border Padding="16"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        CornerRadius="8"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1">
+                    <StackPanel Spacing="8">
+                        <TextBlock FontSize="12"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   TextWrapping="Wrap"
+                                   Text="Press Ctrl+/ or F1 anywhere in the app to open this reference." />
+                        <ContentControl x:Name="ShortcutsHost"
+                                        HorizontalContentAlignment="Stretch" />
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+
             <!-- About -->
             <StackPanel Spacing="8">
                 <TextBlock Text="About" FontSize="16" FontWeight="SemiBold" />


### PR DESCRIPTION
## Summary
Adds a central keyboard-shortcuts reference with **two surfaces fed by one catalog**:

### Surfaces
1. **Ctrl+/ or F1** anywhere in the app → ContentDialog listing every hotkey grouped by category
2. **Settings → Keyboard Shortcuts** section (new) renders the same view so browsing without a shortcut works

### Catalog
- `Models/ShortcutsCatalog.h` — struct + list + `BuildShortcutsView()` helper. Adding a new hotkey = append one line; both surfaces update automatically.
- Key cap styling: monospace font + rounded border so 'Ctrl+S' reads like a key, not a word

### Shortcut change
- **Dropped Ctrl+C row-copy** in DataGridView — it hijacked the native TextBox Ctrl+C during inline cell edit, so users trying to copy a single cell got the whole row. `CopySelectedRowToClipboard()` kept in place for a future context-menu wiring.

## Files
- **New:** `windows/Gridex/Models/ShortcutsCatalog.h`
- **Modified:** `MainWindow.xaml.cpp/h` (Ctrl+/ + F1 accelerators, dialog impl), `SettingsPage.xaml/cpp` (new section), `DataGridView.cpp` (remove Ctrl+C handler), `Gridex.vcxproj`

## Test plan
- [ ] Ctrl+/ anywhere → dialog opens with grouped shortcuts
- [ ] F1 anywhere → same dialog (fallback for non-US layouts where Oem2 is remapped)
- [ ] Settings → scroll → 'Keyboard Shortcuts' section renders identical list
- [ ] Double-click a cell → Ctrl+C → native TextBox copy works (no full-row dump)
- [ ] Delete key on grid still works (pending-delete mark)