### PR TITLE
fix(windows): new-row INSERT + auto-flush inline cell edit

### DIFF
--- a/windows/Gridex/DataGridView.cpp
+++ b/windows/Gridex/DataGridView.cpp
@@ -59,6 +59,31 @@ namespace winrt::Gridex::implementation
             Grid_KeyDown(sender, e);
         });
 
+        // Pointer pressed anywhere in the grid → flush any in-flight
+        // cell edit. Bubbles from children, so clicking a row, the empty
+        // area below rows, or the scroll background all funnel here.
+        // Skip flush when the press originates inside a TextBox so the
+        // user can reposition the caret in the cell they're editing.
+        this->AddHandler(
+            mux::UIElement::PointerPressedEvent(),
+            winrt::box_value(
+                mux::Input::PointerEventHandler(
+                    [this](winrt::Windows::Foundation::IInspectable const&,
+                           mux::Input::PointerRoutedEventArgs const& e)
+                    {
+                        // Walk up from the hit target; bail if any
+                        // ancestor is a TextBox (click landed inside
+                        // the active edit, not outside it).
+                        auto src = e.OriginalSource().try_as<mux::DependencyObject>();
+                        while (src)
+                        {
+                            if (src.try_as<muxc::TextBox>()) return;
+                            src = muxm::VisualTreeHelper::GetParent(src);
+                        }
+                        FlushEdit();
+                    })),
+            true /* handledEventsToo */);
+
         // Right-click context menu. Host wires OnRefreshRequested /
         // OnDeleteRequested in WorkspacePage; unset = no-op. Delete is
         // disabled for read-only grids (e.g. Redis projections) and when
@@ -852,6 +877,13 @@ namespace winrt::Gridex::implementation
         rowPanel.Children().InsertAt(targetIdx, editBox);
         editBox.Focus(mux::FocusState::Programmatic);
 
+        // Track which cell is editing so FlushEdit() can locate the
+        // TextBox and commit its text on Ctrl+S without waiting for
+        // LostFocus (which doesn't fire when a keyboard accelerator
+        // handles the key at the page level).
+        editingRowIndex_ = rowIndex;
+        editingColIndex_ = static_cast<int>(colIndex);
+
         // Save on Enter key. Empty input -> SQL NULL sentinel.
         editBox.KeyDown([this, rowIndex, colIndex, oldValue]
             (winrt::Windows::Foundation::IInspectable const& sender,
@@ -897,6 +929,11 @@ namespace winrt::Gridex::implementation
         // call (Enter / LostFocus) already committed — bail out.
         if (!rowPanel.Children().GetAt(targetIdx).try_as<muxc::TextBox>()) return;
 
+        // Clear in-flight edit tracking — FlushEdit() relies on this to
+        // know when nothing is being edited.
+        editingRowIndex_ = -1;
+        editingColIndex_ = -1;
+
         auto& colName = data_.columnNames[colIndex];
         data_.rows[rowIndex][colName] = newValue;
 
@@ -933,6 +970,39 @@ namespace winrt::Gridex::implementation
 
         if (newValue != oldValue && OnCellEdited)
             OnCellEdited(rowIndex, colName, oldValue, newValue);
+    }
+
+    // Locate the TextBox for the currently-edited cell and commit its
+    // text synchronously. No-op if nothing is being edited. Used on
+    // Ctrl+S and on "click outside the TextBox" so the user's in-flight
+    // text always lands in ChangeTracker before SQL generation — Enter
+    // is still the dedicated accept key but no longer the only one.
+    void DataGridView::FlushEdit()
+    {
+        if (editingRowIndex_ < 0 || editingColIndex_ < 0) return;
+        const int rowIdx = editingRowIndex_;
+        const int colIdx = editingColIndex_;
+
+        auto rowPanel = GetRowPanel(rowIdx);
+        if (!rowPanel) { editingRowIndex_ = -1; editingColIndex_ = -1; return; }
+        const uint32_t targetIdx = static_cast<uint32_t>(colIdx) + 1u;
+        if (targetIdx >= rowPanel.Children().Size()) { editingRowIndex_ = -1; editingColIndex_ = -1; return; }
+        auto tb = rowPanel.Children().GetAt(targetIdx).try_as<muxc::TextBox>();
+        if (!tb) { editingRowIndex_ = -1; editingColIndex_ = -1; return; }
+
+        std::wstring newValue(tb.Text());
+        // Match existing Enter / LostFocus semantics: an empty TextBox
+        // means "SQL NULL". User who wanted literal empty string still
+        // has to set NULL explicitly elsewhere (same as before).
+        if (newValue.empty()) newValue = DBModels::nullValue();
+
+        if (colIdx >= static_cast<int>(data_.columnNames.size())) return;
+        const auto& colName = data_.columnNames[colIdx];
+        std::wstring oldValue;
+        auto it = data_.rows[rowIdx].find(colName);
+        if (it != data_.rows[rowIdx].end()) oldValue = it->second;
+
+        CommitCellEdit(rowIdx, colIdx, oldValue, newValue);
     }
 
     // ── Key shortcuts: Delete mark-deleted ───

--- a/windows/Gridex/DataGridView.h
+++ b/windows/Gridex/DataGridView.h
@@ -57,6 +57,13 @@ namespace winrt::Gridex::implementation
         // Expose selected row index for CRUD operations
         int GetSelectedRowIndex() const { return selectedRow_; }
 
+        // Flush any in-flight inline cell edit synchronously. Call this
+        // right before committing pending changes (Ctrl+S / Commit button)
+        // so the value still sitting in an unfocused TextBox lands in the
+        // ChangeTracker before SQL is generated. No-op when nothing is
+        // being edited.
+        void FlushEdit();
+
         // Mark a row as deleted (red bg, dimmed text)
         void MarkRowDeleted(int index);
 
@@ -75,6 +82,14 @@ namespace winrt::Gridex::implementation
         DBModels::QueryResult data_;
         std::vector<DBModels::ColumnInfo> columnMetadata_;
         int selectedRow_ = -1;
+
+        // Tracks the (row, col) that is currently in inline-edit mode
+        // (TextBox swapped in place of TextBlock). -1/-1 when nothing is
+        // being edited. Set by BeginCellEdit, cleared by CommitCellEdit;
+        // read by FlushEdit to locate the TextBox and commit its text
+        // without relying on LostFocus timing.
+        int editingRowIndex_ = -1;
+        int editingColIndex_ = -1;
         std::wstring sortColumn_;
         bool sortAscending_ = true;
         bool readOnly_ = false;

--- a/windows/Gridex/MSSQLAdapter.cpp
+++ b/windows/Gridex/MSSQLAdapter.cpp
@@ -652,13 +652,20 @@ namespace DBModels
         bool first = true;
         for (auto& [col, val] : values)
         {
-            if (isNullCell(val)) continue;
+            // Skip SQL NULL (already the case) and blank cells — blank
+            // means "use IDENTITY / DEFAULT / nullable default"; emitting
+            // '' would bomb on INT columns and fight IDENTITY_INSERT.
+            if (isNullCell(val) || val.empty()) continue;
             if (!first) { sql += ", "; vals += ", "; }
             sql += quoteIdentifier(col);
             vals += quoteLiteral(val);
             first = false;
         }
-        sql += ") " + vals + ")";
+        if (first)
+            sql = "INSERT INTO " + quoteIdentifier(sch) + "." +
+                  quoteIdentifier(table) + " DEFAULT VALUES";
+        else
+            sql += ") " + vals + ")";
         return executeInternal(sql);
     }
 

--- a/windows/Gridex/Models/ChangeTracker.h
+++ b/windows/Gridex/Models/ChangeTracker.h
@@ -204,10 +204,28 @@ namespace DBModels
             bool first = true;
             for (auto& [col, val] : edit.insertValues)
             {
+                // Blank cell (user left it empty in the new-row UI) →
+                // omit the column so AUTO_INCREMENT / SERIAL / column
+                // DEFAULT fire. Otherwise we emit '' which bombs on INT
+                // columns and fights auto-increment. Explicit SQL NULL
+                // still travels via the null sentinel (quoteLit → NULL).
+                if (!isNullCell(val) && val.empty()) continue;
                 if (!first) { sql += L", "; vals += L", "; }
                 sql += quoteId(col, dbType);
                 vals += quoteLit(val);
                 first = false;
+            }
+            // All columns blank — use each dialect's all-defaults insert
+            // form so we don't produce invalid "INSERT INTO t () VALUES()".
+            // MySQL accepts "() VALUES ()"; PostgreSQL/SQLite/MSSQL want
+            // "DEFAULT VALUES".
+            if (first)
+            {
+                if (dbType == DatabaseType::MySQL)
+                    return L"INSERT INTO " + qualifiedTable(table, schema, dbType) +
+                           L" () VALUES ()";
+                return L"INSERT INTO " + qualifiedTable(table, schema, dbType) +
+                       L" DEFAULT VALUES";
             }
             sql += L") VALUES (" + vals + L")";
             return sql;

--- a/windows/Gridex/MySQLAdapter.cpp
+++ b/windows/Gridex/MySQLAdapter.cpp
@@ -478,12 +478,23 @@ namespace DBModels
         bool first = true;
         for (auto& [col, val] : values)
         {
+            // Blank cell (user left it empty in the new-row UI) → omit the
+            // column so DB defaults / AUTO_INCREMENT / NULL-by-default kick
+            // in. MySQL otherwise rejects '' for INT columns. Users who
+            // actually want SQL NULL get the null sentinel, which is kept
+            // below and emitted as NULL.
+            if (!isNullCell(val) && val.empty()) continue;
             if (!first) { sql += ", "; valsSql += ", "; }
             sql += quoteIdentifier(col);
             valsSql += isNullCell(val) ? "NULL" : quoteLiteral(val);
             first = false;
         }
-        sql += ") VALUES (" + valsSql + ")";
+        // All columns blank → use MySQL's all-defaults insert form so we
+        // don't produce invalid "INSERT INTO t () VALUES ()".
+        if (first)
+            sql = "INSERT INTO " + quoteIdentifier(schema) + "." + quoteIdentifier(table) + " () VALUES ()";
+        else
+            sql += ") VALUES (" + valsSql + ")";
         return executeInternal(sql);
     }
 

--- a/windows/Gridex/PostgreSQLAdapter.cpp
+++ b/windows/Gridex/PostgreSQLAdapter.cpp
@@ -573,12 +573,20 @@ namespace DBModels
         bool first = true;
         for (auto& [col, val] : values)
         {
+            // Blank cell → omit so SERIAL / DEFAULT / NOT NULL DEFAULT
+            // apply. Users wanting explicit SQL NULL still get the null
+            // sentinel path which emits NULL below.
+            if (!isNullCell(val) && val.empty()) continue;
             if (!first) { sql += ", "; valsSql += ", "; }
             sql     += quoteIdentifier(col);
             valsSql += isNullCell(val) ? "NULL" : quoteLiteral(val);
             first = false;
         }
-        sql += ") VALUES (" + valsSql + ")";
+        // All columns blank → PostgreSQL's canonical all-defaults form.
+        if (first)
+            sql = "INSERT INTO " + quoteIdentifier(schema) + "." + quoteIdentifier(table) + " DEFAULT VALUES";
+        else
+            sql += ") VALUES (" + valsSql + ")";
         return executeInternal(sql);
     }
 

--- a/windows/Gridex/SQLiteAdapter.cpp
+++ b/windows/Gridex/SQLiteAdapter.cpp
@@ -397,12 +397,19 @@ namespace DBModels
         bool first = true;
         for (auto& [col, val] : values)
         {
+            // Blank cell → omit so INTEGER PRIMARY KEY autoincrement and
+            // column DEFAULT expressions fire. Explicit SQL NULL still
+            // travels via the null sentinel.
+            if (!isNullCell(val) && val.empty()) continue;
             if (!first) { sql += ", "; valsSql += ", "; }
             sql += quoteIdentifier(col);
             valsSql += isNullCell(val) ? "NULL" : quoteLiteral(val);
             first = false;
         }
-        sql += ") VALUES (" + valsSql + ")";
+        if (first)
+            sql = "INSERT INTO " + quoteIdentifier(table) + " DEFAULT VALUES";
+        else
+            sql += ") VALUES (" + valsSql + ")";
         return executeInternal(sql);
     }
 

--- a/windows/Gridex/WorkspacePage.cpp
+++ b/windows/Gridex/WorkspacePage.cpp
@@ -1868,6 +1868,14 @@ namespace winrt::Gridex::implementation
 
     void WorkspacePage::CommitChanges()
     {
+        // Flush any in-flight inline cell edit before reading the
+        // change tracker. Without this, pressing Ctrl+S while a TextBox
+        // still holds the newly-typed text would ship the pre-edit
+        // value (often NULL for a freshly-inserted row) because the
+        // commit only fires on Enter / LostFocus and the accelerator
+        // doesn't move focus away from the TextBox.
+        if (auto g = DataGrid().try_as<DataGridView>()) g->FlushEdit();
+
         if (!changeTracker_.hasChanges()) return;
         if (!connMgr_.isConnected()) return;
 


### PR DESCRIPTION
## Summary
Two closely related UX fixes around inserting / committing row changes.

### 1. Blank cells on INSERT → use DB default instead of \`''\`
- \`ChangeTracker::generateInsert\` now **omits columns whose new-row value is blank**. AUTO_INCREMENT / SERIAL / column DEFAULT / nullable-default paths all fire as expected.
- Previously emitted \`INSERT INTO ... (id, title) VALUES ('', 'x')\` — MySQL rejected with *'Incorrect integer value'* on INT columns, and listing \`id\` explicitly would also have blocked AUTO_INCREMENT.
- All-blank rows fall back to each dialect's canonical all-defaults form (\`DEFAULT VALUES\` / \`() VALUES ()\`).
- Same fix applied defensively to MySQL/PostgreSQL/SQLite/MSSQL \`insertRow\` adapter methods (separate code path, still called in some flows).

### 2. Auto-flush the active inline cell edit
- New \`DataGridView::FlushEdit()\` locates the TextBox of the currently-edited cell and commits its text synchronously.
- Called at the top of \`WorkspacePage::CommitChanges\` so **Ctrl+S preserves the typed value**. Without this, the accelerator handled the key at page level, the TextBox never lost focus, LostFocus never fired, and the pre-edit value (often NULL for new rows) was committed instead.
- Grid-level \`PointerPressed\` handler also flushes on click outside the TextBox — clicking another row or the empty area confirms the edit. Clicks landing **inside** the active TextBox walk the visual tree and skip flush so caret repositioning still works.

## Files
- \`windows/Gridex/Models/ChangeTracker.h\` — blank-cell skip + DEFAULT VALUES fallback
- \`windows/Gridex/{MySQL,PostgreSQL,SQLite,MSSQL}Adapter.cpp\` — mirror the blank-skip in \`insertRow\`
- \`windows/Gridex/DataGridView.h/cpp\` — FlushEdit + edit-state tracking + PointerPressed outside-click flush
- \`windows/Gridex/WorkspacePage.cpp\` — wire FlushEdit into CommitChanges

## Test plan
- [ ] Create new row, leave \`id\` blank, type \`title\` only → Ctrl+S → AUTO_INCREMENT fills id (SQL preview shows just \`title\` column)
- [ ] Type into a cell, **don't press Enter**, press Ctrl+S → typed value lands in DB (not NULL / not the old value)
- [ ] Type into a cell, click a different row → edit commits
- [ ] Type into a cell, click inside the same TextBox to reposition caret → edit does NOT commit prematurely
- [ ] Explicit SQL NULL (via clear/null action) still emits NULL, not skipped