### PR TITLE
fix(windows): MySQL external server connect (auth plugin + SSL auto-upgrade)

### DIFF
--- a/windows/Gridex/ConnectionManager.cpp
+++ b/windows/Gridex/ConnectionManager.cpp
@@ -92,6 +92,45 @@ namespace DBModels
         return ok;
     }
 
+    bool ConnectionManager::testConnectionWithError(
+        const ConnectionConfig& config,
+        const std::wstring& password,
+        std::wstring& outError)
+    {
+        outError.clear();
+
+        std::unique_ptr<SSHTunnelService> testTunnel;
+        auto effectiveConfig = applySSHTunnel(config, password, testTunnel);
+
+        auto adapter = createAdapter(config.databaseType);
+
+        // Call adapter->connect directly instead of the bool
+        // testConnection shortcut: connect() throws DatabaseError with
+        // the driver's own message, which is exactly what we want to
+        // surface in the UI.
+        bool ok = false;
+        try
+        {
+            adapter->connect(effectiveConfig, password);
+            auto result = adapter->execute(L"SELECT 1");
+            adapter->disconnect();
+            ok = result.success;
+            if (!ok) outError = result.error;
+        }
+        catch (const std::exception& e)
+        {
+            const std::string w = e.what();
+            outError.assign(w.begin(), w.end());
+        }
+        catch (...)
+        {
+            outError = L"Unknown error";
+        }
+
+        if (testTunnel) testTunnel->close();
+        return ok;
+    }
+
     std::shared_ptr<DatabaseAdapter> ConnectionManager::createAdapter(DatabaseType type)
     {
         switch (type)

--- a/windows/Gridex/HomePage.cpp
+++ b/windows/Gridex/HomePage.cpp
@@ -366,13 +366,15 @@ namespace winrt::Gridex::implementation
                     try
                     {
                         DBModels::ConnectionManager mgr;
-                        if (!mgr.testConnection(config, config.password))
+                        std::wstring err;
+                        if (!mgr.testConnectionWithError(config, config.password, err))
                         {
+                            std::wstring msg = L"Could not connect to " + config.name + L".";
+                            if (!err.empty()) msg += L"\n\n" + err;
+                            else msg += L" Check host, port, credentials, and ensure the server is running.";
                             muxc::ContentDialog errDlg;
                             errDlg.Title(winrt::box_value(winrt::hstring(L"Connection Failed")));
-                            errDlg.Content(winrt::box_value(winrt::hstring(
-                                L"Could not connect to " + config.name +
-                                L". Check host, port, credentials, and ensure the server is running.")));
+                            errDlg.Content(winrt::box_value(winrt::hstring(msg)));
                             errDlg.CloseButtonText(L"OK");
                             errDlg.XamlRoot(this->XamlRoot());
                             errDlg.ShowAsync();
@@ -504,13 +506,15 @@ namespace winrt::Gridex::implementation
         try
         {
             DBModels::ConnectionManager mgr;
-            if (!mgr.testConnection(selectedConn, selectedConn.password))
+            std::wstring err;
+            if (!mgr.testConnectionWithError(selectedConn, selectedConn.password, err))
             {
+                std::wstring msg = L"Could not connect to " + selectedConn.name + L".";
+                if (!err.empty()) msg += L"\n\n" + err;
+                else msg += L" Check host, port, credentials, and ensure the server is running.";
                 muxc::ContentDialog errDlg;
                 errDlg.Title(winrt::box_value(winrt::hstring(L"Connection Failed")));
-                errDlg.Content(winrt::box_value(winrt::hstring(
-                    L"Could not connect to " + selectedConn.name +
-                    L". Check host, port, credentials, and ensure the server is running.")));
+                errDlg.Content(winrt::box_value(winrt::hstring(msg)));
                 errDlg.CloseButtonText(L"OK");
                 errDlg.XamlRoot(this->XamlRoot());
                 errDlg.ShowAsync();

--- a/windows/Gridex/Models/ConnectionManager.h
+++ b/windows/Gridex/Models/ConnectionManager.h
@@ -37,6 +37,15 @@ namespace DBModels
             const ConnectionConfig& config,
             const std::wstring& password);
 
+        // Same as testConnection but surfaces the underlying adapter
+        // error message (libpq / libmariadb / sqlite3 text) so UI can
+        // show the real reason instead of a generic "check host/port"
+        // line. outError stays empty when the call returns true.
+        bool testConnectionWithError(
+            const ConnectionConfig& config,
+            const std::wstring& password,
+            std::wstring& outError);
+
         // Get the active adapter (nullptr if not connected)
         std::shared_ptr<DatabaseAdapter> getActiveAdapter() const { return activeAdapter_; }
 

--- a/windows/Gridex/MySQLAdapter.cpp
+++ b/windows/Gridex/MySQLAdapter.cpp
@@ -83,18 +83,62 @@ namespace DBModels
         // Set UTF-8
         mysql_options(conn_, MYSQL_SET_CHARSET_NAME, "utf8mb4");
 
-        // SSL — respect sslMode: Preferred/Required skip cert verification
-        // (common for self-signed certs); VerifyCA/VerifyIdentity enforce it.
-        if (config.sslMode != DBModels::SSLMode::Disabled)
+        // SSL policy.
+        //
+        // MariaDB Connector/C 3.4 (vcpkg build) auto-upgrades the
+        // connection to TLS whenever the server advertises CLIENT_SSL —
+        // even if the caller never touched any SSL option. The client's
+        // default cert-verify flag is TRUE, so a self-signed / untrusted
+        // server cert then bombs with "Certificate verification failure:
+        // The certificate is NOT trusted", turning what the user picked
+        // as "Disabled" into a verification failure instead of a plain
+        // TCP connect. macOS MySQLNIO doesn't have this auto-upgrade so
+        // the same server works there with Disabled.
+        //
+        // Pragmatic fix: always disable cert verification UNLESS the
+        // user explicitly picked VerifyCA / VerifyIdentity. That covers
+        // Disabled (may or may not get SSL silently, but won't fail on
+        // cert), Preferred, and Required.
         {
-            mysql_ssl_set(conn_, nullptr, nullptr, nullptr, nullptr, nullptr);
+            bool wantSSL =
+                (config.sslMode != DBModels::SSLMode::Disabled);
+            unsigned char enforce = wantSSL ? 1 : 0;
+            mysql_options(conn_, MYSQL_OPT_SSL_ENFORCE, &enforce);
 
             bool verifyCert =
                 (config.sslMode == DBModels::SSLMode::VerifyCA ||
                  config.sslMode == DBModels::SSLMode::VerifyIdentity);
             unsigned char verify = verifyCert ? 1 : 0;
             mysql_options(conn_, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &verify);
+
+            if (wantSSL)
+            {
+                mysql_ssl_set(conn_, nullptr, nullptr, nullptr, nullptr, nullptr);
+            }
         }
+
+        // MariaDB Connector/C 3.4+ defaults its restricted_auth list to
+        // a subset that on some vcpkg builds **excludes**
+        // mysql_native_password — the most common MySQL auth plugin and
+        // the one MySQLNIO (macOS Gridex) has no problem with. On
+        // Windows this caused "Authentication plugin 'mysql_native_password'
+        // couldn't be found in restricted_auth plugin list." whenever a
+        // server's user account wasn't on caching_sha2_password.
+        //
+        // NOTE: passing "" would mean "whitelist = nothing" → block
+        // every plugin, which is worse. Pass an explicit whitelist
+        // covering every plugin libmariadb supports and that real
+        // servers actually use. Mirrors the mysql CLI behaviour.
+        static const char* kAllowedAuthPlugins =
+            "mysql_native_password,"
+            "caching_sha2_password,"
+            "sha256_password,"
+            "mysql_clear_password,"
+            "dialog,"
+            "auth_gssapi_client,"
+            "client_ed25519";
+        mysql_optionsv(conn_, MARIADB_OPT_RESTRICTED_AUTH,
+                       (void*)kAllowedAuthPlugins);
 
         auto host = toUtf8(config.host);
         auto user = toUtf8(config.username);


### PR DESCRIPTION
## Summary
Windows users couldn't connect to external MySQL servers that macOS connected to fine. Root cause: two behavioural quirks in the vcpkg libmariadb 3.4.8 build, neither of which MySQLNIO (macOS) has.

### Bug 1 — Auth plugin whitelist excludes mysql_native_password
libmariadb 3.4 ships a default \`restricted_auth\` list that doesn't include \`mysql_native_password\` — the most common server-side auth plugin. Handshake aborted with:
> Authentication plugin 'mysql_native_password' couldn't be found in restricted_auth plugin list.

**Fix:** explicit \`MARIADB_OPT_RESTRICTED_AUTH\` whitelist covering every real plugin (native / sha2 / ed25519 / gssapi / dialog / clear / sha256).

### Bug 2 — SSL silently upgrades + cert verify on by default
libmariadb 3.4 auto-upgrades to TLS whenever the server advertises \`CLIENT_SSL\`, even when the client didn't ask for SSL. Default \`verify_server_cert\` is TRUE, so self-signed server certs bombed with:
> TLS/SSL error: Certificate verification failure: The certificate is NOT trusted.

…turning 'Disabled' SSL mode into a cert verification failure.

**Fix:** always pin \`MYSQL_OPT_SSL_VERIFY_SERVER_CERT = 0\` unless the user explicitly chose VerifyCA / VerifyIdentity. Disabled / Preferred / Required now never fail on cert trust.

### Nice-to-have — surface the real driver error
Previously the UI showed a generic 'Check host, port, credentials, and ensure the server is running.' regardless of what actually went wrong. Added \`ConnectionManager::testConnectionWithError\` that propagates the libmariadb / libpq / sqlite3 message to the dialog, which is what let us diagnose the two bugs above.

## Files
- \`windows/Gridex/MySQLAdapter.cpp\` — auth whitelist + SSL policy
- \`windows/Gridex/Models/ConnectionManager.h\` + \`ConnectionManager.cpp\` — new \`testConnectionWithError\`
- \`windows/Gridex/HomePage.cpp\` — use the new method, show real error

## Test plan
- [ ] External MySQL (mysql_native_password) + SSL Disabled → connects
- [ ] External MySQL + SSL Preferred → connects (unverified SSL)
- [ ] External MySQL + SSL Required → connects, SSL enforced
- [ ] External MySQL + SSL VerifyCA with proper CA → connects, verified
- [ ] External MySQL + SSL VerifyCA with self-signed → fails with clear cert error
- [ ] Local Docker MySQL + SSL Disabled → still connects (regression check)
- [ ] Bad password → dialog shows 'Access denied for user ...' instead of generic line