### PR TITLE
fix(windows): pending-delete red mark survives selection changes

### DIFF
--- a/windows/Gridex/DataGridView.cpp
+++ b/windows/Gridex/DataGridView.cpp
@@ -177,6 +177,11 @@ namespace winrt::Gridex::implementation
     {
         data_        = result;
         selectedRow_ = -1;
+        // New data set = prior row indices are meaningless; drop the
+        // pending-delete visual bookkeeping. Host (WorkspacePage) also
+        // discards its ChangeTracker on table switch, so the two stay
+        // in sync.
+        deletedRows_.clear();
 
         // EXPLAIN / EXPLAIN ANALYZE (and similar verbatim single-column
         // outputs) must not be truncated at 80 chars — each row is a
@@ -767,6 +772,21 @@ namespace winrt::Gridex::implementation
         auto sp = findRowPanelByDataIndex(DataRows(), index);
         if (!sp) return;
 
+        // Pending-delete visual wins over alternate-row shading: if the
+        // row is in deletedRows_, paint it red + dim regardless of
+        // whether it's currently selected. This prevents an earlier
+        // delete's red mark from disappearing when the user clicks a
+        // different row (which triggered HighlightRow on the previous
+        // row and unconditionally reset its background).
+        const bool isDeleted = (deletedRows_.count(index) > 0);
+        if (isDeleted)
+        {
+            sp.Background(muxm::SolidColorBrush(
+                winrt::Windows::UI::ColorHelper::FromArgb(40, 196, 43, 28)));
+            sp.Opacity(0.5);
+            return;
+        }
+
         if (index == selectedRow_)
         {
             sp.Background(muxm::SolidColorBrush(
@@ -780,6 +800,7 @@ namespace winrt::Gridex::implementation
                 : winrt::Windows::UI::Colors::Transparent();
             sp.Background(muxm::SolidColorBrush(bg));
         }
+        sp.Opacity(1.0);
     }
 
     // ── Mark/clear row visual states ─────────────────
@@ -787,6 +808,9 @@ namespace winrt::Gridex::implementation
     {
         if (index < 0 || index >= static_cast<int>(data_.rows.size()))
             return;
+        // Track the delete so HighlightRow / row rebuild can re-paint
+        // it when selection changes or the grid re-renders.
+        deletedRows_.insert(index);
         auto sp = findRowPanelByDataIndex(DataRows(), index);
         if (!sp) return;
         sp.Background(muxm::SolidColorBrush(
@@ -796,6 +820,7 @@ namespace winrt::Gridex::implementation
 
     void DataGridView::ClearRowMarks()
     {
+        deletedRows_.clear();
         for (uint32_t i = 0; i < DataRows().Children().Size(); i++)
         {
             auto sp = DataRows().Children().GetAt(i).try_as<muxc::StackPanel>();

--- a/windows/Gridex/DataGridView.h
+++ b/windows/Gridex/DataGridView.h
@@ -4,6 +4,7 @@
 #include "Models/QueryResult.h"
 #include "Models/ColumnInfo.h"
 #include <functional>
+#include <set>
 
 namespace winrt::Gridex::implementation
 {
@@ -90,6 +91,15 @@ namespace winrt::Gridex::implementation
         // without relying on LostFocus timing.
         int editingRowIndex_ = -1;
         int editingColIndex_ = -1;
+
+        // Row indices the user has marked for deletion (pending commit).
+        // Kept here — not just in ChangeTracker — so HighlightRow /
+        // BuildRowElement can re-apply the red "pending delete" visual
+        // whenever a row is re-rendered (selection change, sort, page
+        // switch). Previously only the last-deleted row showed red
+        // because HighlightRow unconditionally reset the background on
+        // selection change.
+        std::set<int> deletedRows_;
         std::wstring sortColumn_;
         bool sortAscending_ = true;
         bool readOnly_ = false;


### PR DESCRIPTION
## Summary
Only the most recently-deleted row kept its red 'pending delete' visual. Clicking another row (or deleting a second one) wiped the red from the first — even though ChangeTracker still had the pending DELETE queued, so commit issued every DELETE correctly. UI lied.

## Root cause
\`HighlightRow\` unconditionally repainted the previous selection's background when focus moved. It had no way to know the row was still pending deletion, so it treated it like any other unselected row.

## Fix
DataGridView now owns \`std::set<int> deletedRows_\`:
- \`MarkRowDeleted\` adds to the set + applies the red / dim visual
- \`ClearRowMarks\` (Discard path) clears the set + resets visuals
- \`SetData\` clears the set (new table / reload = old indices meaningless)
- \`HighlightRow\` checks the set **first** and paints red + Opacity(0.5) regardless of selection state

## Files
- \`windows/Gridex/DataGridView.h\` — new \`deletedRows_\` member
- \`windows/Gridex/DataGridView.cpp\` — updates to MarkRowDeleted / ClearRowMarks / HighlightRow / SetData

## Test plan
- [ ] Delete row 0 → red. Delete row 1 → both still red
- [ ] Click row 2 (non-deleted) → row 0 and row 1 stay red
- [ ] Click row 0 (deleted) → stays red (no blue selection override)
- [ ] Discard → all red marks cleared
- [ ] Commit → rows actually removed from DB (regression check)
- [ ] Reload / switch tables → set cleared, no ghost marks