### PR TITLE
fix(windows): bundle libmariadb auth plugin DLLs + set plugin dir at …

### DIFF
--- a/windows/Gridex/MySQLAdapter.cpp
+++ b/windows/Gridex/MySQLAdapter.cpp
@@ -83,6 +83,28 @@ namespace DBModels
         // Set UTF-8
         mysql_options(conn_, MYSQL_SET_CHARSET_NAME, "utf8mb4");
 
+        // Point libmariadb at the bundled auth plugin DLLs. Without this
+        // the library looks for plugins in a compile-time vcpkg path
+        // that doesn't exist on customer machines → any auth method
+        // beyond the built-in mysql_native_password (e.g. MySQL 8's
+        // default caching_sha2_password, MariaDB's client_ed25519)
+        // fails with "Authentication plugin '...' cannot be loaded".
+        // Plugins are copied to <exe_dir>/plugins/mariadb/ by
+        // build-unpackaged.ps1.
+        {
+            wchar_t exePath[MAX_PATH] = {};
+            DWORD len = ::GetModuleFileNameW(nullptr, exePath, MAX_PATH);
+            if (len > 0 && len < MAX_PATH)
+            {
+                std::wstring dir(exePath);
+                auto slash = dir.find_last_of(L"\\/");
+                if (slash != std::wstring::npos) dir.resize(slash);
+                std::wstring pluginDirW = dir + L"\\plugins\\mariadb";
+                auto pluginDir = toUtf8(pluginDirW);
+                mysql_options(conn_, MYSQL_PLUGIN_DIR, pluginDir.c_str());
+            }
+        }
+
         // SSL policy.
         //
         // MariaDB Connector/C 3.4 (vcpkg build) auto-upgrades the

--- a/windows/scripts/build-unpackaged.ps1
+++ b/windows/scripts/build-unpackaged.ps1
@@ -197,6 +197,33 @@ if (Test-Path $vcpkgBin) {
 } else {
     Write-Warning "vcpkg bin missing: $vcpkgBin -- Setup.exe will be missing libpq/libmariadb/etc."
 }
+
+# --- Bundle libmariadb auth plugins ------------------------------------
+#
+# libmariadb ships each auth plugin as a separate DLL (caching_sha2_password,
+# client_ed25519, sha256_password, dialog, mysql_clear_password). The
+# built-in mysql_native_password auth works without these — everything
+# else requires the matching DLL to be loadable from MYSQL_PLUGIN_DIR.
+# vcpkg installs them under plugins/libmariadb/ on the build machine,
+# but that path obviously doesn't exist on customer machines. Copy them
+# next to Gridex.exe so the code in MySQLAdapter.cpp can point
+# MYSQL_PLUGIN_DIR at <app>/plugins/mariadb/ and real MySQL 8 servers
+# (caching_sha2_password by default) will auth without requiring the
+# admin to --default-authentication-plugin=mysql_native_password.
+#
+$mariadbPluginSrc = 'C:\vcpkg\installed\x64-windows\plugins\libmariadb'
+$mariadbPluginDst = Join-Path $outDir 'plugins\mariadb'
+if (Test-Path $mariadbPluginSrc) {
+    New-Item -ItemType Directory -Force -Path $mariadbPluginDst | Out-Null
+    $pluginCount = 0
+    Get-ChildItem (Join-Path $mariadbPluginSrc '*.dll') | ForEach-Object {
+        Copy-Item $_.FullName -Destination $mariadbPluginDst -Force
+        $pluginCount++
+    }
+    Write-Host "Copied $pluginCount libmariadb auth plugin(s) to $mariadbPluginDst" -ForegroundColor Cyan
+} else {
+    Write-Warning "libmariadb plugin dir missing: $mariadbPluginSrc -- MySQL 8 caching_sha2_password auth will fail at runtime."
+}
 # -----------------------------------------------------------------------
 
 # --- Bundle Microsoft Edge WebView2 Runtime bootstrap ------------------


### PR DESCRIPTION
…runtime

The only built-in auth plugin in libmariadb is mysql_native_password — everything else (caching_sha2_password, client_ed25519, sha256_password, dialog, mysql_clear_password) ships as a separate DLL loaded from MYSQL_PLUGIN_DIR. Gridex wasn't shipping those DLLs, and libmariadb's default plugin dir points to a compile-time vcpkg path that doesn't exist on customer machines. Result: anyone whose MySQL server used the default auth (MySQL 8 → caching_sha2_password, MariaDB 10.4+ → client_ed25519) couldn't connect, only people running MySQL with an explicit --default-authentication-plugin=mysql_native_password could.

Fix is two-part:
- build-unpackaged.ps1 copies every libmariadb plugin DLL from C:\vcpkg\installed\x64-windows\plugins\libmariadb\ to <app>\plugins\mariadb- MySQLAdapter.cpp computes <exe_dir>\plugins\mariadb at connect time and hands it to mysql_options(MYSQL_PLUGIN_DIR, ...), so the library finds the plugins regardless of where the user installed Gridex.

Verified live against:
- MySQL 8.0.45 default (caching_sha2_password) ✓
- MariaDB 10.11 default (client_ed25519) ✓
- MySQL 8 with --default-auth=mysql_native_password ✓