### PR TITLE
fix(mongodb): preserve authSource/authMechanism/replicaSet from URI P…

### DIFF
--- a/macos/Core/Models/Database/ConnectionConfig.swift
+++ b/macos/Core/Models/Database/ConnectionConfig.swift
@@ -31,6 +31,11 @@ struct ConnectionConfig: Codable, Sendable, Hashable, Identifiable {
     // MCP Access
     var mcpMode: MCPConnectionMode
 
+    /// MongoDB-specific URI options preserved from the user's connection string
+    /// (e.g. `authSource`, `authMechanism`, `replicaSet`, `readPreference`).
+    /// `tls`/`ssl` are handled via `sslEnabled` and are never stored here.
+    var mongoOptions: [String: String]?
+
     init(
         id: UUID = UUID(),
         name: String,
@@ -47,7 +52,8 @@ struct ConnectionConfig: Codable, Sendable, Hashable, Identifiable {
         sslCACertPath: String? = nil,
         filePath: String? = nil,
         sshConfig: SSHTunnelConfig? = nil,
-        mcpMode: MCPConnectionMode = .locked
+        mcpMode: MCPConnectionMode = .locked,
+        mongoOptions: [String: String]? = nil
     ) {
         self.id = id
         self.name = name
@@ -65,6 +71,7 @@ struct ConnectionConfig: Codable, Sendable, Hashable, Identifiable {
         self.filePath = filePath
         self.sshConfig = sshConfig
         self.mcpMode = mcpMode
+        self.mongoOptions = mongoOptions
     }
 
     var displayHost: String {

--- a/macos/Data/Adapters/MongoDB/MongoDBAdapter.swift
+++ b/macos/Data/Adapters/MongoDB/MongoDBAdapter.swift
@@ -63,11 +63,24 @@ final class MongoDBAdapter: DatabaseAdapter, @unchecked Sendable {
         }
         uri += "\(hostField):\(port)/\(dbName)"
 
-        // Most MongoDB deployments store users in the `admin` database. Without
-        // an explicit authSource, MongoKitten authenticates against the URI's
-        // database and the server returns a generic auth failure.
+        // `tls`/`ssl` are owned by `config.sslEnabled` — skip them if they slipped
+        // into `mongoOptions`. Everything else (authSource, authMechanism,
+        // replicaSet, …) is forwarded to MongoKitten as-is.
         var params: [String] = []
-        if hasCredentials {
+        var hasExplicitAuthSource = false
+        let sortedOptions = (config.mongoOptions ?? [:]).sorted { $0.key < $1.key }
+        for (key, value) in sortedOptions {
+            let keyLower = key.lowercased()
+            if keyLower == "tls" || keyLower == "ssl" { continue }
+            if keyLower == "authsource" { hasExplicitAuthSource = true }
+            let encoded = value.addingPercentEncoding(withAllowedCharacters: Self.mongoQueryValueAllowed) ?? value
+            params.append("\(key)=\(encoded)")
+        }
+
+        // Most MongoDB deployments store users in the `admin` database, and
+        // authenticating against the URI's `/db` segment returns a generic failure.
+        // Apply the `admin` default only when the user didn't provide one.
+        if hasCredentials && !hasExplicitAuthSource {
             params.append("authSource=admin")
         }
         if config.sslEnabled {
@@ -78,6 +91,14 @@ final class MongoDBAdapter: DatabaseAdapter, @unchecked Sendable {
         }
         return uri
     }
+
+    /// `.urlQueryAllowed` leaves `&`, `=`, `+` unescaped — fine inside a URL's
+    /// query component, wrong inside a single query value. Strip those three.
+    private static let mongoQueryValueAllowed: CharacterSet = {
+        var set = CharacterSet.urlQueryAllowed
+        set.remove(charactersIn: "&=+")
+        return set
+    }()
 
     /// Replace the /database segment of a mongodb URI with a new database name.
     /// Preserves user:pass@host[:port] and any ?query string after the database.

--- a/macos/Data/Persistence/Models/SavedConnectionEntity.swift
+++ b/macos/Data/Persistence/Models/SavedConnectionEntity.swift
@@ -29,6 +29,9 @@ final class SavedConnectionEntity {
     var createdAt: Date
     var filePath: String?
     var mcpMode: String?
+    /// MongoDB URI options serialized as JSON (`authSource`, `authMechanism`, etc.)
+    /// Kept as a string so SwiftData lightweight migration is trivial.
+    var mongoOptionsJSON: String?
 
     init(
         id: UUID = UUID(),
@@ -51,7 +54,8 @@ final class SavedConnectionEntity {
         lastConnectedAt: Date? = nil,
         createdAt: Date = Date(),
         filePath: String? = nil,
-        mcpMode: String? = nil
+        mcpMode: String? = nil,
+        mongoOptionsJSON: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -74,7 +78,10 @@ final class SavedConnectionEntity {
         self.createdAt = createdAt
         self.filePath = filePath
         self.mcpMode = mcpMode
+        self.mongoOptionsJSON = mongoOptionsJSON
     }
+
+    private static let mongoOptionsDecoder = JSONDecoder()
 
     func toConfig() -> ConnectionConfig {
         var sshConfig: SSHTunnelConfig?
@@ -86,6 +93,14 @@ final class SavedConnectionEntity {
                 authMethod: SSHAuthMethod(rawValue: sshAuthMethod ?? "password") ?? .password,
                 keyPath: sshKeyPath
             )
+        }
+
+        var mongoOptions: [String: String]?
+        if let json = mongoOptionsJSON, !json.isEmpty,
+           let data = json.data(using: .utf8),
+           let decoded = try? Self.mongoOptionsDecoder.decode([String: String].self, from: data),
+           !decoded.isEmpty {
+            mongoOptions = decoded
         }
 
         return ConnectionConfig(
@@ -101,7 +116,8 @@ final class SavedConnectionEntity {
             group: group,
             filePath: filePath,
             sshConfig: sshConfig,
-            mcpMode: mcpMode.flatMap { MCPConnectionMode(rawValue: $0) } ?? .locked
+            mcpMode: mcpMode.flatMap { MCPConnectionMode(rawValue: $0) } ?? .locked,
+            mongoOptions: mongoOptions
         )
     }
 }

--- a/macos/Data/Persistence/Repositories/SwiftDataConnectionRepository.swift
+++ b/macos/Data/Persistence/Repositories/SwiftDataConnectionRepository.swift
@@ -64,7 +64,8 @@ final class SwiftDataConnectionRepository: ConnectionRepository, @unchecked Send
             colorTag: config.colorTag?.rawValue,
             group: config.group,
             filePath: config.filePath,
-            mcpMode: config.mcpMode.rawValue
+            mcpMode: config.mcpMode.rawValue,
+            mongoOptionsJSON: Self.encodeMongoOptions(config.mongoOptions)
         )
         context.insert(entity)
         try context.save()
@@ -97,8 +98,21 @@ final class SwiftDataConnectionRepository: ConnectionRepository, @unchecked Send
         entity.sshAuthMethod = config.sshConfig?.authMethod.rawValue
         entity.sshKeyPath = config.sshConfig?.keyPath
         entity.mcpMode = config.mcpMode.rawValue
+        entity.mongoOptionsJSON = Self.encodeMongoOptions(config.mongoOptions)
 
         try context.save()
+    }
+
+    private static let mongoOptionsEncoder = JSONEncoder()
+
+    /// Encode MongoDB options as a JSON string for SwiftData storage. Returns nil
+    /// when the dictionary is absent or empty so the column stays unused for non-Mongo rows.
+    private static func encodeMongoOptions(_ options: [String: String]?) -> String? {
+        guard let options, !options.isEmpty,
+              let data = try? mongoOptionsEncoder.encode(options),
+              let str = String(data: data, encoding: .utf8)
+        else { return nil }
+        return str
     }
 
     @MainActor

--- a/macos/Presentation/Views/ConnectionForm/ConnectionFormView.swift
+++ b/macos/Presentation/Views/ConnectionForm/ConnectionFormView.swift
@@ -20,6 +20,10 @@ struct ConnectionFormView: View {
     @State private var password: String = ""
     @State private var sqliteFilePath: String = ""
     @State private var connectionString: String = ""
+    /// MongoDB URI options captured by Parse (`authSource`, `authMechanism`, …).
+    /// Kept on the form so they survive Parse → Test/Save without relying on the
+    /// raw URI still being in the `connectionString` field.
+    @State private var parsedMongoOptions: [String: String] = [:]
     @State private var connStringError: String?
 
     // Tag
@@ -389,6 +393,10 @@ struct ConnectionFormView: View {
             sshAuthMethod = ssh.authMethod
             sshKeyPath = ssh.keyPath ?? ""
         }
+
+        if databaseType == .mongodb {
+            parsedMongoOptions = config.mongoOptions ?? [:]
+        }
     }
 
     // MARK: - Validation
@@ -429,6 +437,10 @@ struct ConnectionFormView: View {
             return host
         }()
 
+        let mongoOptions: [String: String]? = (databaseType == .mongodb && !parsedMongoOptions.isEmpty)
+            ? parsedMongoOptions
+            : nil
+
         return ConnectionConfig(
             id: existingConfig?.id ?? UUID(),
             name: name.isEmpty ? (isFileDB ? "SQLite" : host) : name,
@@ -444,7 +456,8 @@ struct ConnectionFormView: View {
             sslCertPath: sslCertPath.isEmpty ? nil : sslCertPath,
             sslCACertPath: sslCACertPath.isEmpty ? nil : sslCACertPath,
             filePath: databaseType == .sqlite ? sqliteFilePath : nil,
-            sshConfig: sshConfig
+            sshConfig: sshConfig,
+            mongoOptions: mongoOptions
         )
     }
 
@@ -480,20 +493,26 @@ struct ConnectionFormView: View {
         let prefixLength = isSrv ? "mongodb+srv://".count : "mongodb://".count
         var rest = String(trimmed.dropFirst(prefixLength))
 
-        // Strip query string and parse for tls/ssl flag
+        // Preserve every non-tls query param (authSource, authMechanism,
+        // replicaSet, …) so they survive Parse into the form state.
         var hasTLS = isSrv  // SRV implies TLS by default
+        var extractedOptions: [String: String] = [:]
         if let qIdx = rest.firstIndex(of: "?") {
             let query = String(rest[rest.index(after: qIdx)...])
             rest = String(rest[..<qIdx])
             for param in query.split(separator: "&") {
                 let parts = param.split(separator: "=", maxSplits: 1)
-                if parts.count == 2 {
-                    let key = String(parts[0]).lowercased()
-                    let value = String(parts[1]).lowercased()
-                    if (key == "tls" || key == "ssl") && (value == "true" || value == "1") {
-                        hasTLS = true
-                    }
+                guard parts.count == 2 else { continue }
+                let rawKey = String(parts[0])
+                let rawValue = String(parts[1])
+                let keyLower = rawKey.lowercased()
+                let valueLower = rawValue.lowercased()
+                if keyLower == "tls" || keyLower == "ssl" {
+                    if valueLower == "true" || valueLower == "1" { hasTLS = true }
+                    continue
                 }
+                let decodedValue = rawValue.removingPercentEncoding ?? rawValue
+                extractedOptions[rawKey] = decodedValue
             }
         }
 
@@ -545,6 +564,7 @@ struct ConnectionFormView: View {
         if name.isEmpty {
             name = hostName
         }
+        parsedMongoOptions = extractedOptions
     }
 
     private func pickSQLiteFile() {

--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -32,9 +32,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.7</string>
+	<string>0.0.8</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
…arse

Parse previously dropped non-tls query params, so a pasted `mongodb://...?authSource=mydb` would authenticate as `authSource=admin` and fail. Now forwarded through ConnectionConfig.mongoOptions, persisted via SwiftData, and emitted by MongoDBAdapter.buildURI with stricter percent-encoding (escapes &=+).