### PR TITLE
fix(menu): remove duplicate Settings… item in app menu (#26)

### DIFF
--- a/macos/App/Lifecycle/GridexApp.swift
+++ b/macos/App/Lifecycle/GridexApp.swift
@@ -21,13 +21,6 @@ struct GridexApp: App {
         .defaultSize(width: 900, height: 500)
         .windowToolbarStyle(.unified(showsTitle: false))
         .commands {
-            CommandGroup(replacing: .appSettings) {
-                Button("Settings...") {
-                    currentAppState?.showSettings = true
-                }
-                .keyboardShortcut(",", modifiers: .command)
-            }
-
             CommandGroup(after: .appInfo) {
                 Button("Check for Updates…") {
                     updater.checkForUpdates()

--- a/macos/App/State/AppState.swift
+++ b/macos/App/State/AppState.swift
@@ -41,7 +41,6 @@ final class AppState: ObservableObject {
     @Published var aiPanelVisible = false
     @Published var showDBTypePicker = false
     @Published var showConnectionForm = false
-    @Published var showSettings = false
     @Published var showDatabaseSwitcher = false
     @Published var showNewTableSheet = false
     @Published var selectedDBType: DatabaseType?


### PR DESCRIPTION
The app menu showed two "Settings…" entries because GridexApp declared both a custom CommandGroup(replacing: .appSettings) and a Settings { SettingsView() } scene, which SwiftUI auto-populates with its own menu item. The custom button was also inert — it toggled AppState.showSettings, which nothing observed.

Drop the custom CommandGroup and the orphaned showSettings property; the Settings scene retains the standard ⌘, shortcut.