### PR TITLE
fix(linux/mcp): don't reply to notifications; correct Linux client paths

### DIFF
--- a/linux/src/Presentation/Views/MCP/MCPSetupView.cpp
+++ b/linux/src/Presentation/Views/MCP/MCPSetupView.cpp
@@ -33,12 +33,12 @@ struct ClientSpec {
     const char* pathTemplate;   // ~/ is expanded
 };
 
+// Linux-only clients. Claude Desktop has no Linux build, so it's omitted.
 static const ClientSpec kClients[] = {
-    {"claude_desktop", "Claude Desktop",
-     "~/.config/Claude/claude_desktop_config.json"},
-    {"cursor",         "Cursor",        "~/.cursor/mcp.json"},
-    {"windsurf",       "Windsurf",      "~/.windsurf/mcp.json"},
-    {"claude_code",    "Claude Code",   "~/.claude/settings.json"},
+    {"claude_code", "Claude Code",  "~/.claude.json"},
+    {"cursor",      "Cursor",       "~/.cursor/mcp.json"},
+    {"windsurf",    "Windsurf",     "~/.codeium/windsurf/mcp_config.json"},
+    {"gemini_cli",  "Gemini CLI",   "~/.gemini/settings.json"},
 };
 
 QString expand(const QString& p) {

--- a/linux/src/Services/MCP/MCPServer.cpp
+++ b/linux/src/Services/MCP/MCPServer.cpp
@@ -61,8 +61,12 @@ void MCPServer::start() {
     startTime_ = std::chrono::system_clock::now();
     if (transport_) {
         transport_->setHandler([this](const JSONRPCRequest& req) {
+            // JSON-RPC 2.0: notifications have no `id` and MUST NOT receive a
+            // response. Claude Code drops the connection if it gets an
+            // unsolicited response (zod validation rejects id=null).
+            const bool isNotification = req.id.is_null();
             auto resp = handleRequest(req);
-            transport_->send(resp);
+            if (!isNotification) transport_->send(resp);
         });
         transport_->start();
     }


### PR DESCRIPTION
## Summary
Two Linux-specific MCP fixes that were blocking Claude Code from actually using the Gridex MCP server.

### 1. Unsolicited response to JSON-RPC notifications
The stdio transport handler was sending a response for every incoming request, including notifications like \`initialized\`. Claude Code validates each response with zod and rejects \`id: null\` — right after \`initialize\` succeeded, Claude dropped the stdio connection and marked the server as failed.

Gate the send on \`!req.id.is_null()\` so notifications are silent per JSON-RPC 2.0 spec.

Verified end-to-end:
- \`claude mcp list\` → \`gridex ✓ Connected\`
- Tool calls through Claude succeed (\`list_connections\`, \`list_tables\`, \`query\`)

### 2. Setup tab listed clients with the wrong paths
The client picker showed Claude Desktop (no Linux build) and used macOS/Windows paths for the others. Replaced with Linux-correct paths:

| Client | Path |
|---|---|
| Claude Code | \`~/.claude.json\` (top-level \`mcpServers\`) |
| Cursor | \`~/.cursor/mcp.json\` |
| Windsurf | \`~/.codeium/windsurf/mcp_config.json\` |
| Gemini CLI | \`~/.gemini/settings.json\` |

Claude Desktop is omitted — no Linux build exists.

## Test plan
- [x] \`echo '{...initialized notification...}' | gridex --mcp-stdio\` — no response emitted
- [x] \`echo '{...initialize...}' | gridex --mcp-stdio\` — response emitted, valid JSON-RPC 2.0
- [x] \`claude mcp list\` shows \`gridex ✓ Connected\`
- [x] Call \`list_connections\` via Claude CLI → returns configured non-Locked connections
- [x] Call \`query\` with \`SELECT sqlite_version()\` → executes and returns result with columns metadata
- [x] Setup tab → Install button writes to \`~/.claude.json\` with gridex entry at top-level \`mcpServers\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)