### PR TITLE
fix(postgres): show all schemas (not just public) on Supabase (#34)

### DIFF
--- a/macos/Data/Adapters/PostgreSQL/PostgreSQLAdapter.swift
+++ b/macos/Data/Adapters/PostgreSQL/PostgreSQLAdapter.swift
@@ -231,10 +231,19 @@ final class PostgreSQLAdapter: DatabaseAdapter, SchemaInspectable, @unchecked Se
     }
 
     func listSchemas(database: String?) async throws -> [String] {
+        // Query pg_namespace directly rather than information_schema.schemata.
+        // The latter is defined (per SQL standard) to filter rows by
+        // `pg_has_role(owner, 'USAGE') OR has_schema_privilege('USAGE, CREATE')`,
+        // so on Supabase — where the `postgres` role is NOSUPERUSER and schemas
+        // like `auth`, `storage`, `realtime`, `extensions`, `graphql` are owned
+        // by `supabase_admin` without a USAGE grant — everything except `public`
+        // silently disappears. pg_namespace is readable by all roles and returns
+        // every physical schema, matching what pgAdmin/TablePlus/DBeaver show.
         let result = try await executeRaw(sql: """
-            SELECT schema_name FROM information_schema.schemata
-            WHERE schema_name NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
-            ORDER BY schema_name
+            SELECT nspname FROM pg_namespace
+            WHERE nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+              AND nspname !~ '^pg_(temp|toast_temp)_'
+            ORDER BY nspname
             """)
         return result.rows.compactMap { $0.first?.stringValue }
     }

--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -32,9 +32,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.11</string>
+	<string>0.0.12</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Closes #34.

## Summary
- `listSchemas` was using `information_schema.schemata`, a SQL-standard view whose rows are filtered by `pg_has_role(owner, 'USAGE') OR has_schema_privilege('USAGE, CREATE')`.
- On Supabase, the connecting `postgres` role is NOSUPERUSER and has no `USAGE` on the internal schemas (`auth`, `storage`, `realtime`, `extensions`, `graphql`), which are owned by `supabase_admin`. Result: only `public` shows in the sidebar.
- Switched to `pg_namespace`, which isn't privilege-filtered. Matches pgAdmin / TablePlus / DBeaver behaviour. Same system-schema exclusions kept, plus a regex dropping transient `pg_temp_*` / `pg_toast_temp_*` (previously hidden by the view).

## Risk
Low — single adapter, single query change.

- Other adapters (MySQL, SQLite, Mongo, Redis, ClickHouse, MSSQL): untouched.
- If the role lacks USAGE on a newly-visible schema, expanding it calls `listTables`, which still queries `information_schema.tables` — also privilege-filtered — so it silently returns empty, no crash. Opening a specific table would throw a normal Postgres permission error (expected semantics, not a regression).
- `fullSchemaSnapshot` iterates `listTables` output per schema; empty results add no tasks, so no new throw surface.

## Verification
Reproduced Supabase's role layout locally (PG 16, `postgres` NOSUPERUSER, `supabase_admin` owning internal schemas with no USAGE grant). The old query returned `public` only; the new query returns all six schemas.

## Test plan
- [ ] Connect to a Supabase project and confirm `auth`, `storage`, `realtime`, etc. appear in the sidebar.
- [ ] Expand one of them — should list no tables (role lacks privilege) rather than crash.
- [ ] Existing PostgreSQL connections on self-hosted / RDS still show user schemas only, with the system schemas correctly hidden.
- [ ] SQL editor / data grid for `public` schema continues to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)