### PR TITLE
v0.1.8: connection-click loading overlay

### DIFF
--- a/windows/Gridex/HomePage.cpp
+++ b/windows/Gridex/HomePage.cpp
@@ -506,60 +506,76 @@ namespace winrt::Gridex::implementation
     {
         if (!e.ClickedItem()) return;
 
-        // ClickedItem returns the ConnectionCard UserControl
-        // Read Tag to find connection id
+        // Read the connection id from the ConnectionCard's Tag.
         winrt::hstring connId;
         if (auto fe = e.ClickedItem().try_as<winrt::Microsoft::UI::Xaml::FrameworkElement>())
         {
             if (auto tag = fe.Tag())
                 connId = winrt::unbox_value<winrt::hstring>(tag);
         }
-
         if (connId.empty()) return;
 
-        // Find the connection config
         DBModels::ConnectionConfig selectedConn;
         bool found = false;
         for (const auto& conn : allConnections_)
         {
             if (conn.id == std::wstring(connId))
-            {
-                selectedConn = conn;
-                found = true;
-                break;
-            }
+            { selectedConn = conn; found = true; break; }
         }
         if (!found) return;
 
-        // Test connection BEFORE navigating to workspace. If the test
-        // fails, show error on HomePage so the user doesn't land on a
-        // blank workspace with an error dialog they have to dismiss.
         auto frame = this->Frame();
         if (!frame) return;
 
-        try
-        {
-            DBModels::ConnectionManager mgr;
-            std::wstring err;
-            if (!mgr.testConnectionWithError(selectedConn, selectedConn.password, err))
-            {
-                std::wstring msg = L"Could not connect to " + selectedConn.name + L".";
-                if (!err.empty()) msg += L"\n\n" + err;
-                else msg += L" Check host, port, credentials, and ensure the server is running.";
-                muxc::ContentDialog errDlg;
-                errDlg.Title(winrt::box_value(winrt::hstring(L"Connection Failed")));
-                errDlg.Content(winrt::box_value(winrt::hstring(msg)));
-                errDlg.CloseButtonText(L"OK");
-                errDlg.XamlRoot(this->XamlRoot());
-                errDlg.ShowAsync();
-                return;
-            }
-        }
-        catch (...) {}
+        // Show the loading overlay so the user gets visual feedback
+        // during the connect probe (otherwise the UI looks frozen,
+        // especially for SSH tunnels / cold remote DBs).
+        ConnectingText().Text(L"Connecting to " + selectedConn.name + L"...");
+        ConnectingOverlay().Visibility(mux::Visibility::Visible);
 
-        auto workspace = winrt::make<WorkspacePage>();
-        workspace.as<WorkspacePage>()->SetConnection(selectedConn, selectedConn.password);
-        frame.Content(workspace);
+        // Capture a strong ref + dispatcher so the worker thread can
+        // bounce back to the UI thread to flip visibility / navigate
+        // / show the error dialog. std::thread is detached — fire and
+        // forget; the strong ref keeps the page alive long enough.
+        auto self = get_strong();
+        auto dispatcher = this->DispatcherQueue();
+        auto config = selectedConn;
+        auto password = selectedConn.password;
+
+        std::thread([self, dispatcher, config, password, frame]() mutable
+        {
+            bool ok = false;
+            std::wstring err;
+            try
+            {
+                DBModels::ConnectionManager mgr;
+                ok = mgr.testConnectionWithError(config, password, err);
+            }
+            catch (...) { ok = false; }
+
+            dispatcher.TryEnqueue([self, ok, err, config, password, frame]() mutable
+            {
+                self->ConnectingOverlay().Visibility(mux::Visibility::Collapsed);
+
+                if (!ok)
+                {
+                    std::wstring msg = L"Could not connect to " + config.name + L".";
+                    if (!err.empty()) msg += L"\n\n" + err;
+                    else msg += L" Check host, port, credentials, and ensure the server is running.";
+                    muxc::ContentDialog errDlg;
+                    errDlg.Title(winrt::box_value(winrt::hstring(L"Connection Failed")));
+                    errDlg.Content(winrt::box_value(winrt::hstring(msg)));
+                    errDlg.CloseButtonText(L"OK");
+                    errDlg.XamlRoot(self->XamlRoot());
+                    errDlg.ShowAsync();
+                    return;
+                }
+
+                auto workspace = winrt::make<WorkspacePage>();
+                workspace.as<WorkspacePage>()->SetConnection(config, password);
+                frame.Content(workspace);
+            });
+        }).detach();
     }
 
     void HomePage::SearchBox_TextChanged(

--- a/windows/Gridex/HomePage.h
+++ b/windows/Gridex/HomePage.h
@@ -30,6 +30,10 @@ namespace winrt::Gridex::implementation
         winrt::fire_and_forget ImportConnections_Click(
             winrt::Windows::Foundation::IInspectable const& sender,
             winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
+        // Spawns a worker thread for the connect probe so the UI
+        // thread stays responsive (loading overlay animates), then
+        // bounces back via DispatcherQueue::TryEnqueue to navigate
+        // or surface the error dialog.
         void ConnectionItem_Click(
             winrt::Windows::Foundation::IInspectable const& sender,
             winrt::Microsoft::UI::Xaml::Controls::ItemClickEventArgs const& e);

--- a/windows/Gridex/HomePage.xaml
+++ b/windows/Gridex/HomePage.xaml
@@ -198,5 +198,25 @@
                         Click="NewConnection_Click" />
             </StackPanel>
         </Grid>
+
+        <!-- Modal loading overlay shown while ConnectionItem_Click tests
+             the selected connection. Sits on top of every column and
+             intercepts clicks via IsHitTestVisible default true. -->
+        <Grid x:Name="ConnectingOverlay"
+              Grid.Column="0" Grid.ColumnSpan="3"
+              Background="#80000000"
+              Visibility="Collapsed">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center"
+                        Spacing="12" Padding="32"
+                        Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
+                        BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                        BorderThickness="1" CornerRadius="8">
+                <ProgressRing IsActive="True" Width="40" Height="40" />
+                <TextBlock x:Name="ConnectingText"
+                           Text="Connecting..."
+                           HorizontalAlignment="Center"
+                           FontSize="13" />
+            </StackPanel>
+        </Grid>
     </Grid>
 </Page>

--- a/windows/README.md
+++ b/windows/README.md
@@ -66,29 +66,29 @@ windows/scripts/
 **Git Bash / MSYS2**:
 ```bash
 cd /e/dev/be/vura
-powershell -NoProfile -ExecutionPolicy Bypass -File ./windows/scripts/build-and-pack.ps1 -Version "0.1.7"
+powershell -NoProfile -ExecutionPolicy Bypass -File ./windows/scripts/build-and-pack.ps1 -Version "0.1.8"
 ```
 
 **PowerShell (5.1 / 7+)**:
 ```powershell
 cd E:\dev\be\vura
-powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-and-pack.ps1 -Version "0.1.7"
+powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-and-pack.ps1 -Version "0.1.8"
 ```
 
 **CMD**:
 ```cmd
 cd /d E:\dev\be\vura
-powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-and-pack.ps1 -Version "0.1.7"
+powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-and-pack.ps1 -Version "0.1.8"
 ```
 
 Script sẽ:
 1. Cài/update `vpk` global tool (skip nếu đã có)
-2. Build `Gridex.exe` unpackaged, stamp version `0.1.7` vào About section
-3. Pack thành `Setup.exe` qua Velopack với metadata version `0.1.7`
+2. Build `Gridex.exe` unpackaged, stamp version `0.1.8` vào About section
+3. Pack thành `Setup.exe` qua Velopack với metadata version `0.1.8`
 
 **Output**: `windows/Releases/`
 - `Gridex-stable-Setup.exe` — installer user-facing
-- `Gridex-0.1.7-stable-full.nupkg` — package Velopack
+- `Gridex-0.1.8-stable-full.nupkg` — package Velopack
 - `releases.stable.json`, `RELEASES-stable` — feed manifests
 - `Gridex-stable-Portable.zip` — bản portable
 
@@ -140,7 +140,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\install-vp
 powershell -NoProfile -ExecutionPolicy Bypass -File ./windows/scripts/build-unpackaged.ps1
 
 # Build với version cụ thể — About section hiện đúng string
-powershell -NoProfile -ExecutionPolicy Bypass -File ./windows/scripts/build-unpackaged.ps1 -Version "0.1.7-test"
+powershell -NoProfile -ExecutionPolicy Bypass -File ./windows/scripts/build-unpackaged.ps1 -Version "0.1.8-test"
 ```
 
 **PowerShell**:
@@ -149,7 +149,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File ./windows/scripts/build-unpa
 powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-unpackaged.ps1
 
 # Build với version cụ thể — About section hiện đúng string
-powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-unpackaged.ps1 -Version "0.1.7-test"
+powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-unpackaged.ps1 -Version "0.1.8-test"
 ```
 
 **CMD**:
@@ -158,7 +158,7 @@ REM Dev build — About section hiện "0.0.0-dev"
 powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-unpackaged.ps1
 
 REM Build với version cụ thể — About section hiện đúng string
-powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-unpackaged.ps1 -Version "0.1.7-test"
+powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-unpackaged.ps1 -Version "0.1.8-test"
 ```
 
 Chạy trực tiếp exe để test nhanh mà không cần cài installer:
@@ -177,17 +177,17 @@ Chạy trực tiếp exe để test nhanh mà không cần cài installer:
 
 **Git Bash / MSYS2**:
 ```bash
-powershell -NoProfile -ExecutionPolicy Bypass -File ./windows/scripts/pack-velopack.ps1 -Version "0.1.7-test"
+powershell -NoProfile -ExecutionPolicy Bypass -File ./windows/scripts/pack-velopack.ps1 -Version "0.1.8-test"
 ```
 
 **PowerShell**:
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\pack-velopack.ps1 -Version "0.1.7-test"
+powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\pack-velopack.ps1 -Version "0.1.8-test"
 ```
 
 **CMD**:
 ```cmd
-powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\pack-velopack.ps1 -Version "0.1.7-test"
+powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\pack-velopack.ps1 -Version "0.1.8-test"
 ```
 
 **Lưu ý**: `-Version` truyền vào `pack-velopack.ps1` **phải khớp** với `-Version` truyền vào `build-unpackaged.ps1`, nếu không thì Velopack sẽ in một số, còn About section của app sẽ in số khác. Dùng `build-and-pack.ps1` ở trên để tránh trường hợp này.
@@ -196,10 +196,10 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\pack-velop
 
 - `windows/Gridex/GridexVersion.h` — include unconditional file generated
 - `windows/Gridex/GridexVersion.generated.h` — **auto-generated, gitignored**, do `build-unpackaged.ps1` ghi mỗi lần chạy
-  - Có `-Version` → `#define GRIDEX_VERSION L"0.1.7"`
+  - Có `-Version` → `#define GRIDEX_VERSION L"0.1.8"`
   - Không `-Version` → `#define GRIDEX_VERSION L"0.0.0-dev"`
 - `windows/Gridex/SettingsPage.xaml.cpp` — đọc `GRIDEX_VERSION` và set vào `VersionText` text block
-- CI workflow `.github/workflows/windows-release.yml` tự parse version từ git tag (`v0.1.7` → `0.1.7`) và forward sang script
+- CI workflow `.github/workflows/windows-release.yml` tự parse version từ git tag (`v0.1.8` → `0.1.8`) và forward sang script
 
 Build script chỉ rewrite `GridexVersion.generated.h` khi nội dung khác → không force recompile vô ích.
 
@@ -209,17 +209,17 @@ Mặc định Velopack dùng channel `stable`. Nếu muốn phát hành kênh ri
 
 **Git Bash / MSYS2**:
 ```bash
-powershell -NoProfile -ExecutionPolicy Bypass -File ./windows/scripts/build-and-pack.ps1 -Version "0.1.7-beta.1" -Channel "beta"
+powershell -NoProfile -ExecutionPolicy Bypass -File ./windows/scripts/build-and-pack.ps1 -Version "0.1.8-beta.1" -Channel "beta"
 ```
 
 **PowerShell**:
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-and-pack.ps1 -Version "0.1.7-beta.1" -Channel "beta"
+powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-and-pack.ps1 -Version "0.1.8-beta.1" -Channel "beta"
 ```
 
 **CMD**:
 ```cmd
-powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-and-pack.ps1 -Version "0.1.7-beta.1" -Channel "beta"
+powershell -NoProfile -ExecutionPolicy Bypass -File .\windows\scripts\build-and-pack.ps1 -Version "0.1.8-beta.1" -Channel "beta"
 ```
 
 Output sẽ là `Gridex-beta-Setup.exe` + `releases.beta.json` — auto-updater phân luồng theo channel.
@@ -253,7 +253,7 @@ Chưa cài đủ vcpkg deps. Xem section "Cài vcpkg deps" ở đầu file.
 ### Gridex.exe crash ngay khi khởi động với `MSVCP140.dll not found`
 Máy thiếu VC++ 2015-2022 Redistributable. Script `build-unpackaged.ps1` tự copy CRT DLLs vào output folder → nếu vẫn lỗi thì check VS install path / logs script.
 
-### Setup.exe cài xong nhưng About hiện `0.0.0-dev` dù pack với `-Version 0.1.7`
+### Setup.exe cài xong nhưng About hiện `0.0.0-dev` dù pack với `-Version 0.1.8`
 Dùng `build-and-pack.ps1` thay vì gọi `pack-velopack.ps1` trực tiếp. Trường hợp chạy `pack-velopack.ps1` với version khác version lúc build `Gridex.exe` → xóa `windows\Gridex\x64\Release\` rồi build lại đúng thứ tự.
 
 ### Lỗi `pwsh.exe exited with code 9009` trong vcpkg applocal step
@@ -288,8 +288,8 @@ del /q .\windows\Gridex\GridexVersion.generated.h
 CI tự chạy khi push tag matching `v*.*.*`:
 
 ```bash
-git tag v0.1.7
-git push origin v0.1.7
+git tag v0.1.8
+git push origin v0.1.8
 ```
 
 GitHub Actions workflow `windows-release.yml` sẽ tự build + pack + upload assets lên GitHub Release. Xem chi tiết ở `.github/workflows/windows-release.yml`.


### PR DESCRIPTION
## Summary

UX fix: HomePage froze for 0.5–3s on every connection click while the synchronous testConnection probe ran on the UI thread (especially painful for SSH tunnels and cold remote DBs).

### Features
- **Loading overlay** on connection click — semi-transparent backdrop + ProgressRing + "Connecting to <name>..." text. Shows immediately, hides on completion.
- Probe now runs on a `std::thread`; `DispatcherQueue::TryEnqueue` bounces back to the UI thread to navigate or surface the error dialog. Strong-ref capture keeps the page alive for the worker.

## Test plan
- [x] Build Debug x64 clean
- [x] Click connection → overlay visible, ProgressRing spins
- [x] Successful connect → navigates to WorkspacePage, overlay dismissed
- [x] Failed connect → error dialog, overlay dismissed