### PR TITLE
docs(readme): prominent Download section for all 3 platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,30 @@
 
 ---
 
+## Download
+
+<p align="center">
+  <a href="https://cdn.gridex.app/macos/Gridex-0.0.11-universal.dmg"><img src="https://img.shields.io/badge/Download-macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS"></a>
+  &nbsp;
+  <a href="https://cdn.gridex.app/windows/Gridex-stable-Setup.exe"><img src="https://img.shields.io/badge/Download-Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows"></a>
+  &nbsp;
+  <a href="https://cdn.gridex.app/linux/Gridex-latest-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download for Linux"></a>
+</p>
+
+<p align="center">
+  <sub>
+    <b>macOS</b> — universal DMG (Apple Silicon + Intel), signed &amp; notarized, auto-update via Sparkle ·
+    <b>Windows</b> — Velopack installer, Windows 10/11 ·
+    <b>Linux</b> — x86_64 AppImage, Qt 6, self-update from JSON feed
+  </sub>
+</p>
+
+<p align="center">
+  <sub>Looking for a specific version, delta updates, or checksums? See <a href="https://github.com/gridex/gridex/releases">all releases</a> or the <a href="https://gridex.app/download">download page</a>.</sub>
+</p>
+
+---
+
 ## Supported Databases
 
 <p align="center">


### PR DESCRIPTION
Add a Download section right after the hero image so visitors can grab a build in one click without scrolling past the feature walkthrough or hunting through the Releases page.

- macOS — direct link to the universal DMG on the R2 CDN (Apple Silicon + Intel, signed & notarized, Sparkle-fed).
- Windows — `Gridex-stable-Setup.exe` (stable alias on R2, no version pinning needed).
- Linux — `Gridex-latest-x86_64.AppImage` (latest alias on R2, self-update via JSON feed).

Verified all three URLs return HTTP 200. Subtext lists platform specifics; a secondary line points power users at the full Releases page and gridex.app/download for delta updates and checksums.

Caveat: the macOS DMG link is version-pinned (no `stable`/`latest` alias on R2 yet), so this line needs bumping each macOS release until the publish script grows an alias upload step.