### PR TITLE
fix(postgres): honor 5-state SSLMode and gate PostgresClient.run()

### DIFF
--- a/macos/Core/Models/Database/ConnectionConfig.swift
+++ b/macos/Core/Models/Database/ConnectionConfig.swift
@@ -14,6 +14,9 @@ struct ConnectionConfig: Codable, Sendable, Hashable, Identifiable {
     var database: String?
     var username: String?
     var sslEnabled: Bool
+    /// Fine-grained SSL posture; `nil` falls back to `sslEnabled` via
+    /// `effectiveSSLMode` for rows persisted before incident `6a4aad0`.
+    var sslMode: SSLMode?
     var colorTag: ColorTag?
     var group: String?
 
@@ -45,6 +48,7 @@ struct ConnectionConfig: Codable, Sendable, Hashable, Identifiable {
         database: String? = nil,
         username: String? = nil,
         sslEnabled: Bool = false,
+        sslMode: SSLMode? = nil,
         colorTag: ColorTag? = nil,
         group: String? = nil,
         sslKeyPath: String? = nil,
@@ -63,6 +67,7 @@ struct ConnectionConfig: Codable, Sendable, Hashable, Identifiable {
         self.database = database
         self.username = username
         self.sslEnabled = sslEnabled
+        self.sslMode = sslMode
         self.colorTag = colorTag
         self.group = group
         self.sslKeyPath = sslKeyPath
@@ -79,6 +84,13 @@ struct ConnectionConfig: Codable, Sendable, Hashable, Identifiable {
             return filePath ?? "Unknown"
         }
         return "\(host ?? "localhost"):\(port ?? databaseType.defaultPort)"
+    }
+
+    /// Resolved SSL posture. Honors the persisted 5-state `sslMode`; falls back
+    /// to `sslEnabled` for rows saved before the field existed (legacy
+    /// `sslEnabled=true` maps to `.preferred`, matching the pre-fix adapter).
+    var effectiveSSLMode: SSLMode {
+        sslMode ?? (sslEnabled ? .preferred : .disabled)
     }
 }
 

--- a/macos/Data/Adapters/PostgreSQL/PostgreSQLAdapter.swift
+++ b/macos/Data/Adapters/PostgreSQL/PostgreSQLAdapter.swift
@@ -28,31 +28,7 @@ final class PostgreSQLAdapter: DatabaseAdapter, SchemaInspectable, @unchecked Se
         let username = config.username ?? "postgres"
         let database = config.database ?? username
 
-        let tlsConfig: PostgresClient.Configuration.TLS
-        if config.sslEnabled {
-            var tls = TLSConfiguration.makeClientConfiguration()
-
-            // Load client certificate and key for mTLS (e.g., Teleport)
-            if let certPath = config.sslCertPath, !certPath.isEmpty,
-               let keyPath = config.sslKeyPath, !keyPath.isEmpty {
-                let cert = try NIOSSLCertificate.fromPEMFile(certPath)
-                let key = try NIOSSLPrivateKey(file: keyPath, format: .pem)
-                tls.certificateChain = cert.map { .certificate($0) }
-                tls.privateKey = .privateKey(key)
-            }
-
-            // Load CA certificate for server verification
-            if let caPath = config.sslCACertPath, !caPath.isEmpty {
-                tls.trustRoots = .file(caPath)
-                tls.certificateVerification = .fullVerification
-            } else {
-                tls.certificateVerification = .none
-            }
-
-            tlsConfig = .prefer(tls)
-        } else {
-            tlsConfig = .disable
-        }
+        let tlsConfig = try Self.makeTLSConfig(for: config.effectiveSSLMode, config: config)
 
         let pgConfig = PostgresClient.Configuration(
             host: host,
@@ -66,12 +42,55 @@ final class PostgreSQLAdapter: DatabaseAdapter, SchemaInspectable, @unchecked Se
         let newClient = PostgresClient(configuration: pgConfig)
         self.client = newClient
 
-        // PostgresClient requires run() in a background task
-        self.clientTask = Task { await newClient.run() }
+        // Querying before PostgresClient.run() is scheduled surfaces a bare
+        // `_ConnectionPoolModule.ConnectionPoolError` that hides the real cause;
+        // reproduces on slow handshakes (e.g. HighGo Secure login-audit NOTICE).
+        // The continuation guarantees the spawned Task body has been entered;
+        // the trailing yield lets run() reach its first suspension point.
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            self.clientTask = Task {
+                cont.resume()
+                await newClient.run()
+            }
+        }
+        await Task.yield()
 
-        // Verify the connection works
         _ = try await newClient.query("SELECT 1")
         isConnected = true
+    }
+
+    private static func makeTLSConfig(
+        for mode: SSLMode,
+        config: ConnectionConfig
+    ) throws -> PostgresClient.Configuration.TLS {
+        if mode == .disabled { return .disable }
+
+        var tls = TLSConfiguration.makeClientConfiguration()
+
+        // mTLS client cert (e.g. Teleport).
+        if let certPath = config.sslCertPath, !certPath.isEmpty,
+           let keyPath = config.sslKeyPath, !keyPath.isEmpty {
+            let cert = try NIOSSLCertificate.fromPEMFile(certPath)
+            let key = try NIOSSLPrivateKey(file: keyPath, format: .pem)
+            tls.certificateChain = cert.map { .certificate($0) }
+            tls.privateKey = .privateKey(key)
+        }
+
+        // libpq semantics: PREFERRED/REQUIRED encrypt only; VERIFY_CA verifies
+        // the chain; VERIFY_IDENTITY also verifies the hostname.
+        switch mode {
+        case .verifyCA, .verifyIdentity:
+            if let caPath = config.sslCACertPath, !caPath.isEmpty {
+                tls.trustRoots = .file(caPath)
+            }
+            tls.certificateVerification = (mode == .verifyIdentity) ? .fullVerification : .noHostnameVerification
+        default:
+            tls.certificateVerification = .none
+        }
+
+        // .prefer falls back to plaintext when the server refuses TLS;
+        // every stricter mode requires a successful TLS handshake.
+        return (mode == .preferred) ? .prefer(tls) : .require(tls)
     }
 
     func disconnect() async throws {

--- a/macos/Data/Persistence/Models/SavedConnectionEntity.swift
+++ b/macos/Data/Persistence/Models/SavedConnectionEntity.swift
@@ -19,6 +19,10 @@ final class SavedConnectionEntity {
     /// Fine-grained SSL posture (raw value of `SSLMode`). Optional for SwiftData
     /// lightweight migration of pre-existing rows. Read site falls back to `sslEnabled`.
     var sslMode: String?
+    /// Optional SSL certificate paths. Kept optional for lightweight migration.
+    var sslKeyPath: String?
+    var sslCertPath: String?
+    var sslCACertPath: String?
     var sshEnabled: Bool
     var sshHost: String?
     var sshPort: Int?
@@ -46,6 +50,9 @@ final class SavedConnectionEntity {
         username: String? = nil,
         sslEnabled: Bool = false,
         sslMode: String? = nil,
+        sslKeyPath: String? = nil,
+        sslCertPath: String? = nil,
+        sslCACertPath: String? = nil,
         sshEnabled: Bool = false,
         sshHost: String? = nil,
         sshPort: Int? = nil,
@@ -70,6 +77,9 @@ final class SavedConnectionEntity {
         self.username = username
         self.sslEnabled = sslEnabled
         self.sslMode = sslMode
+        self.sslKeyPath = sslKeyPath
+        self.sslCertPath = sslCertPath
+        self.sslCACertPath = sslCACertPath
         self.sshEnabled = sshEnabled
         self.sshHost = sshHost
         self.sshPort = sshPort
@@ -120,6 +130,9 @@ final class SavedConnectionEntity {
             sslMode: sslMode.flatMap { SSLMode(rawValue: $0) },
             colorTag: colorTag.flatMap { ColorTag(rawValue: $0) },
             group: group,
+            sslKeyPath: sslKeyPath,
+            sslCertPath: sslCertPath,
+            sslCACertPath: sslCACertPath,
             filePath: filePath,
             sshConfig: sshConfig,
             mcpMode: mcpMode.flatMap { MCPConnectionMode(rawValue: $0) } ?? .locked,

--- a/macos/Data/Persistence/Models/SavedConnectionEntity.swift
+++ b/macos/Data/Persistence/Models/SavedConnectionEntity.swift
@@ -16,6 +16,9 @@ final class SavedConnectionEntity {
     var database: String?
     var username: String?
     var sslEnabled: Bool
+    /// Fine-grained SSL posture (raw value of `SSLMode`). Optional for SwiftData
+    /// lightweight migration of pre-existing rows. Read site falls back to `sslEnabled`.
+    var sslMode: String?
     var sshEnabled: Bool
     var sshHost: String?
     var sshPort: Int?
@@ -42,6 +45,7 @@ final class SavedConnectionEntity {
         database: String? = nil,
         username: String? = nil,
         sslEnabled: Bool = false,
+        sslMode: String? = nil,
         sshEnabled: Bool = false,
         sshHost: String? = nil,
         sshPort: Int? = nil,
@@ -65,6 +69,7 @@ final class SavedConnectionEntity {
         self.database = database
         self.username = username
         self.sslEnabled = sslEnabled
+        self.sslMode = sslMode
         self.sshEnabled = sshEnabled
         self.sshHost = sshHost
         self.sshPort = sshPort
@@ -112,6 +117,7 @@ final class SavedConnectionEntity {
             database: database,
             username: username,
             sslEnabled: sslEnabled,
+            sslMode: sslMode.flatMap { SSLMode(rawValue: $0) },
             colorTag: colorTag.flatMap { ColorTag(rawValue: $0) },
             group: group,
             filePath: filePath,

--- a/macos/Data/Persistence/Repositories/SwiftDataConnectionRepository.swift
+++ b/macos/Data/Persistence/Repositories/SwiftDataConnectionRepository.swift
@@ -56,6 +56,9 @@ final class SwiftDataConnectionRepository: ConnectionRepository, @unchecked Send
             username: config.username,
             sslEnabled: config.sslEnabled,
             sslMode: config.sslMode?.rawValue,
+            sslKeyPath: config.sslKeyPath,
+            sslCertPath: config.sslCertPath,
+            sslCACertPath: config.sslCACertPath,
             sshEnabled: config.sshConfig != nil,
             sshHost: config.sshConfig?.host,
             sshPort: config.sshConfig?.port,
@@ -90,6 +93,9 @@ final class SwiftDataConnectionRepository: ConnectionRepository, @unchecked Send
         entity.username = config.username
         entity.sslEnabled = config.sslEnabled
         entity.sslMode = config.sslMode?.rawValue
+        entity.sslKeyPath = config.sslKeyPath
+        entity.sslCertPath = config.sslCertPath
+        entity.sslCACertPath = config.sslCACertPath
         entity.colorTag = config.colorTag?.rawValue
         entity.group = config.group
         entity.filePath = config.filePath

--- a/macos/Data/Persistence/Repositories/SwiftDataConnectionRepository.swift
+++ b/macos/Data/Persistence/Repositories/SwiftDataConnectionRepository.swift
@@ -55,6 +55,7 @@ final class SwiftDataConnectionRepository: ConnectionRepository, @unchecked Send
             database: config.database,
             username: config.username,
             sslEnabled: config.sslEnabled,
+            sslMode: config.sslMode?.rawValue,
             sshEnabled: config.sshConfig != nil,
             sshHost: config.sshConfig?.host,
             sshPort: config.sshConfig?.port,
@@ -88,6 +89,7 @@ final class SwiftDataConnectionRepository: ConnectionRepository, @unchecked Send
         entity.database = config.database
         entity.username = config.username
         entity.sslEnabled = config.sslEnabled
+        entity.sslMode = config.sslMode?.rawValue
         entity.colorTag = config.colorTag?.rawValue
         entity.group = config.group
         entity.filePath = config.filePath

--- a/macos/Presentation/Views/ConnectionForm/ConnectionFormView.swift
+++ b/macos/Presentation/Views/ConnectionForm/ConnectionFormView.swift
@@ -376,7 +376,7 @@ struct ConnectionFormView: View {
         port = String(config.port ?? databaseType.defaultPort)
         database = config.database ?? ""
         username = config.username ?? ""
-        sslMode = config.sslEnabled ? .required : .preferred
+        sslMode = config.effectiveSSLMode
         colorTag = config.colorTag ?? .blue
         sqliteFilePath = config.filePath ?? ""
 
@@ -450,6 +450,7 @@ struct ConnectionFormView: View {
             database: isFileDB ? nil : (database.isEmpty ? nil : database),
             username: (isFileDB || databaseType == .redis) ? nil : username,
             sslEnabled: isFileDB ? false : sslEnabled,
+            sslMode: isFileDB ? nil : sslMode,
             colorTag: colorTag,
             group: existingConfig?.group,
             sslKeyPath: sslKeyPath.isEmpty ? nil : sslKeyPath,


### PR DESCRIPTION
## Motivation

I'm trying to use Gridex to connect to **HighGo Database (瀚高数据库)** — a PostgreSQL-derived database widely deployed across Chinese enterprises and government systems. The specific server I'm targeting is HighGo Secure V4.5.7 (PostgreSQL 12.7 lineage) speaking the standard PostgreSQL v3 wire protocol with `md5` auth and optional TLS — i.e. **nothing exotic** from PostgresNIO's perspective; `psql` connects without trouble.

Yet Gridex consistently failed to connect with an opaque `_ConnectionPoolModule.ConnectionPoolError` and no actionable detail. Tracing the failure end-to-end uncovered three independent latent bugs in the existing PostgreSQL adapter — **all of which also affect mainline PostgreSQL deployments**. HighGo's slightly slower handshake (server-side login-audit `NoticeResponse` adds round-trips) just makes the timing-dependent ones deterministic instead of flaky:

- **`_ConnectionPoolModule.ConnectionPoolError` masks every connect failure** on slow handshakes (race between `PostgresClient.run()` and the first `query()`).
- **`SSLMode.required` / `verifyCA` / `verifyIdentity` silently degrade to `.prefer(tls)`**, allowing plaintext fallback when the user explicitly asked for TLS — a security regression noted in `AGENTS.md` §3.2 incident `6a4aad0` whose adapter-side fix had not landed.
- **mTLS certificate paths (`sslKeyPath` / `sslCertPath` / `sslCACertPath`) were never persisted**, so any saved connection requiring `verifyCA`, `verifyIdentity`, or client-cert auth lost its TLS inputs on restart and could not reconnect.

After this PR Gridex connects to HighGo Secure V4.5.7 cleanly, REQUIRED / VERIFY_* genuinely require a TLS handshake, and saved mTLS connections survive a restart.

## Why — Bug 1: PostgresClient.run() / query() race

`PostgreSQLAdapter.connect()` was:

```swift
let newClient = PostgresClient(configuration: pgConfig)
self.clientTask = Task { await newClient.run() }
_ = try await newClient.query("SELECT 1")  // ← may execute before run() is scheduled
```

`Task { ... }` returns immediately; the spawned task body has not necessarily been entered by the time `query()` requests a connection from the internal pool. PostgresNIO logs:

> `Trying to lease connection from PostgresClient, but PostgresClient.run() hasn't been called yet.`

…and surfaces a bare `_ConnectionPoolModule.ConnectionPoolError` to the caller. The adapter's `formatPostgresError` only matches `PSQLError`, so the underlying cause never reaches the UI — users see `"The operation couldn't be completed."` regardless of whether the real problem was a wrong port, wrong database name, TLS handshake failure, or authentication rejection.

This is timing-dependent and rarely triggers on local PostgreSQL (the handshake is fast, run() reaches its first `await` before the parent schedules its query). It triggers reliably on:

- HighGo Secure (server-side login-audit `NoticeResponse` adds round-trips)
- TLS handshakes over high-latency links
- Anything that delays the parent task's first `await` after spawning

### Fix

Gate the parent on the child Task body actually being entered, then yield once more so `run()` reaches its first suspension point before the first lease:

```swift
await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
    self.clientTask = Task {
        cont.resume()
        await newClient.run()
    }
}
await Task.yield()
_ = try await newClient.query("SELECT 1")
```

Verified by reproducing the warning + `ConnectionPoolError` against HighGo, then confirming the warning disappears and `SELECT 1` succeeds with the gate.

## Why — Bug 2: SSLMode collapsed into a Bool

The connection form has a 5-state SSL picker (`DISABLED / PREFERRED / REQUIRED / VERIFY_CA / VERIFY_IDENTITY`). The form persisted only:

```swift
config.sslEnabled = (sslMode != .disabled)
```

…and the adapter did:

```swift
tlsConfig = config.sslEnabled ? .prefer(tls) : .disable
```

So `REQUIRED`, `VERIFY_CA`, and `VERIFY_IDENTITY` all degraded to `PostgresClient.Configuration.TLS.prefer(tls)`, which **falls back to plaintext** if the server refuses SSL. A user who explicitly checked "REQUIRED" was silently allowed to connect over plaintext — this is the exact failure mode `AGENTS.md` §3.2 records as incident `6a4aad0`. The earlier fix only landed on the UI side; the persistence + adapter side still collapsed.

This is a security regression: libpq REQUIRED requires a TLS handshake.

### Fix

1. `ConnectionConfig.sslMode: SSLMode?` (Optional → Codable back-compat).
2. `SavedConnectionEntity.sslMode: String?` (Optional → SwiftData lightweight migration of pre-existing rows).
3. `ConnectionConfig.effectiveSSLMode` computed property centralizes the legacy fallback (`sslMode ?? (sslEnabled ? .preferred : .disabled)`) so the form, adapter, and any future consumer agree.
4. `PostgreSQLAdapter` factors out `makeTLSConfig(for:config:)` mapping each mode to its libpq-equivalent `PostgresClient.Configuration.TLS`:
   - `disabled` → `.disable`
   - `preferred` → `.prefer(tls)` with `verification = .none`
   - `required` → `.require(tls)` with `verification = .none`
   - `verifyCA` → `.require(tls)` with `verification = .noHostnameVerification` (loads `sslCACertPath` if set)
   - `verifyIdentity` → `.require(tls)` with `verification = .fullVerification`

After this PR, REQUIRED / VERIFY_* genuinely require a TLS handshake.

## Why — Bug 3: mTLS certificate paths were never persisted

`PostgreSQLAdapter.connect()` already supported mTLS — it loaded `sslCertPath` / `sslKeyPath` / `sslCACertPath` from `ConnectionConfig` to populate the `TLSConfiguration`. The connection form already exposed file pickers for all three. **But `SavedConnectionEntity` had no columns for them**, so:

- `Repository.save()` silently dropped the paths.
- `Repository.update()` silently dropped the paths.
- `toConfig()` returned `ConnectionConfig` with `sslCertPath = nil`, etc.

Net effect: any user who configured mTLS (Teleport, managed PG with client-cert auth) or `VERIFY_CA` (custom internal CA) would see their connection work in the current session, then fail to reconnect after restart with no obvious cause — the SSL mode survived, but the inputs that mode needed did not.

### Fix

Add the three optional `String?` columns to `SavedConnectionEntity` (Optional for SwiftData lightweight migration), wire them through `save` / `update` / `toConfig`. The adapter already reads these fields on connect, so persistence is the only missing link.

## Compatibility

- `sslMode`, `sslKeyPath`, `sslCertPath`, `sslCACertPath` are all Optional in both `ConnectionConfig` and the SwiftData entity. Existing `Codable` payloads decode unchanged; SwiftData rows skip the columns without a heavyweight migration.
- `effectiveSSLMode` maps legacy `sslEnabled=true` → `.preferred`, matching the old adapter's actual behavior (`.prefer(tls)`). Users who were silently on prefer remain on prefer; if they wanted REQUIRED they can re-pick once and the new field will store it. No silent upgrade to a stricter mode.
- Other adapters (MySQL / MongoDB / Redis / MSSQL / ClickHouse) still consume the legacy `sslEnabled: Bool`; honouring `sslMode` for them is left as a follow-up.

## Test plan

- [x] `swift build` clean, no new warnings
- [x] Reproduced the race against HighGo Secure V4.5.7 with PostgresNIO 1.32: pre-fix → `ConnectionPoolError`; post-fix → SELECT 1 succeeds, no warning
- [x] Manually exercised `DISABLED` / `PREFERRED` / `REQUIRED` SSL modes against the same server
- [ ] `VERIFY_CA` / `VERIFY_IDENTITY` paths against a server with a known CA — please test if you have a Teleport / managed PG handy; I do not have a verified-CA PG to test against today
- [x] Existing connections (saved before this change) load with `sslMode == nil` and fall back to legacy behaviour via `effectiveSSLMode`
- [ ] Saved a connection with mTLS cert/key/CA paths, restarted Gridex, verified the paths reload from SwiftData and the adapter still finds them on the next connect (please confirm if you have an mTLS endpoint to test against)

## Out of scope (follow-ups)

- Extend `sslMode` honouring to MySQL / MongoDB / Redis / MSSQL / ClickHouse adapters. They currently still consume `sslEnabled: Bool` only — same class of bug, separate PR.
- Eventually deprecate `sslEnabled: Bool` once all adapters honour `sslMode`.
