### PR TITLE
feat(settings): add status bar icon visibility toggle

### DIFF
--- a/macos/Presentation/Windows/Settings/SettingsView.swift
+++ b/macos/Presentation/Windows/Settings/SettingsView.swift
@@ -33,6 +33,7 @@ struct GeneralSettingsView: View {
     @AppStorage("general.autoRefreshSidebar") private var autoRefreshSidebar = true
     @AppStorage("general.refreshInterval") private var refreshInterval = 300 // seconds
     @AppStorage("general.showQueryLog") private var showQueryLog = false
+    @AppStorage("mcp.hideStatusBarIcon") private var hideStatusBarIcon = false
 
     var body: some View {
         Form {
@@ -61,9 +62,18 @@ struct GeneralSettingsView: View {
             Section("Query") {
                 Toggle("Show query log panel by default", isOn: $showQueryLog)
             }
+
+            Section("Status Bar") {
+                Toggle("Hide status bar icon", isOn: $hideStatusBarIcon)
+            }
         }
         .formStyle(.grouped)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onChange(of: hideStatusBarIcon) { _, _ in
+            Task { @MainActor in
+                MCPStatusBarController.shared.refresh()
+            }
+        }
     }
 }
 

--- a/macos/Services/MCP/MCPStatusBarController.swift
+++ b/macos/Services/MCP/MCPStatusBarController.swift
@@ -18,6 +18,10 @@ class MCPStatusBarController: NSObject, NSMenuDelegate {
         UserDefaults.standard.bool(forKey: "mcp.enabled")
     }
 
+    private var shouldHideStatusBarIcon: Bool {
+        UserDefaults.standard.bool(forKey: "mcp.hideStatusBarIcon")
+    }
+
     private override init() {
         super.init()
         setupStatusItem()
@@ -25,13 +29,21 @@ class MCPStatusBarController: NSObject, NSMenuDelegate {
 
     private func setupStatusItem() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
-        statusItem?.isVisible = true
+        applyStatusBarIconVisibility()
         updateIcon()
         setupMenu()
     }
 
     func refresh() {
+        applyStatusBarIconVisibility()
         updateIcon()
+    }
+
+    private func applyStatusBarIconVisibility() {
+        let isVisible = !shouldHideStatusBarIcon
+        guard statusItem?.isVisible != isVisible else { return }
+        statusItem?.isVisible = isVisible
+        print("[MCP Status Bar] Status bar icon \(isVisible ? "shown" : "hidden")")
     }
 
     private func updateIcon() {
@@ -173,10 +185,14 @@ class MCPStatusBarController: NSObject, NSMenuDelegate {
     }
 
     func show() {
-        statusItem?.isVisible = true
+        UserDefaults.standard.set(false, forKey: "mcp.hideStatusBarIcon")
+        applyStatusBarIconVisibility()
+        updateIcon()
     }
 
     func hide() {
-        statusItem?.isVisible = false
+        UserDefaults.standard.set(true, forKey: "mcp.hideStatusBarIcon")
+        applyStatusBarIconVisibility()
+        updateIcon()
     }
 }


### PR DESCRIPTION
## Summary
- Add a General settings toggle to hide the MCP menu bar status icon.
- Persist the preference and apply it when the status item is created.
- Refresh the status item explicitly on setting changes while avoiding repeated visibility writes.

## Test Plan
- [x] swift build
- [x] swift test
- [x] Built and launched dist/Gridex.app, toggled the setting on/off without a crash