### PR TITLE
fix(postgres): list tables from pg_catalog (HighGo Secure dedupe)

### DIFF
--- a/macos/Data/Adapters/PostgreSQL/PostgreSQLAdapter.swift
+++ b/macos/Data/Adapters/PostgreSQL/PostgreSQLAdapter.swift
@@ -8,6 +8,7 @@ import PostgresNIO
 import NIOCore
 import NIOPosix
 import NIOSSL
+import Logging
 
 final class PostgreSQLAdapter: DatabaseAdapter, SchemaInspectable, @unchecked Sendable {
     let databaseType: DatabaseType = .postgresql
@@ -15,6 +16,7 @@ final class PostgreSQLAdapter: DatabaseAdapter, SchemaInspectable, @unchecked Se
     private var client: PostgresClient?
     private var clientTask: Task<Void, Never>?
     private let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+    private let logger = Logger(label: "com.gridex.postgresql")
 
     deinit {
         clientTask?.cancel()
@@ -270,19 +272,20 @@ final class PostgreSQLAdapter: DatabaseAdapter, SchemaInspectable, @unchecked Se
     func listTables(schema: String?) async throws -> [TableInfo] {
         let schemaFilter = schema ?? "public"
         let result = try await executeParameterized(sql: """
-            SELECT t.table_name,
-                   (SELECT reltuples::bigint FROM pg_class c
-                    JOIN pg_namespace n ON n.oid = c.relnamespace
-                    WHERE c.relname = t.table_name AND n.nspname = $1)
-            FROM information_schema.tables t
-            WHERE t.table_schema = $1 AND t.table_type = 'BASE TABLE'
-            ORDER BY t.table_name
+            SELECT c.relname, NULLIF(c.reltuples::bigint, -1)
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = $1
+              AND c.relkind IN ('r', 'p')
+            ORDER BY c.relname
             """, params: [schemaFilter])
-        return result.rows.compactMap { row -> TableInfo? in
+        let tables = result.rows.compactMap { row -> TableInfo? in
             guard let name = row.first?.stringValue else { return nil }
             let count = row.count > 1 ? row[1].intValue : nil
             return TableInfo(name: name, schema: schemaFilter, type: .table, estimatedRowCount: count)
         }
+        logger.debug("Loaded tables", metadata: ["schema": "\(schemaFilter)", "count": "\(tables.count)"])
+        return tables
     }
 
     func listViews(schema: String?) async throws -> [ViewInfo] {

--- a/macos/Data/Adapters/PostgreSQL/PostgreSQLAdapter.swift
+++ b/macos/Data/Adapters/PostgreSQL/PostgreSQLAdapter.swift
@@ -8,7 +8,6 @@ import PostgresNIO
 import NIOCore
 import NIOPosix
 import NIOSSL
-import Logging
 
 final class PostgreSQLAdapter: DatabaseAdapter, SchemaInspectable, @unchecked Sendable {
     let databaseType: DatabaseType = .postgresql
@@ -16,7 +15,6 @@ final class PostgreSQLAdapter: DatabaseAdapter, SchemaInspectable, @unchecked Se
     private var client: PostgresClient?
     private var clientTask: Task<Void, Never>?
     private let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
-    private let logger = Logger(label: "com.gridex.postgresql")
 
     deinit {
         clientTask?.cancel()
@@ -271,21 +269,25 @@ final class PostgreSQLAdapter: DatabaseAdapter, SchemaInspectable, @unchecked Se
 
     func listTables(schema: String?) async throws -> [TableInfo] {
         let schemaFilter = schema ?? "public"
+        // relkind 'r' = ordinary table, 'p' = partitioned table parent.
+        // `NOT relispartition` excludes partition children — they show up as
+        // ordinary 'r' rows but the parent already represents them in the UI;
+        // including them would double-count rows (regression vs the original
+        // information_schema query, which only returned 'BASE TABLE' parents).
         let result = try await executeParameterized(sql: """
             SELECT c.relname, NULLIF(c.reltuples::bigint, -1)
             FROM pg_class c
             JOIN pg_namespace n ON n.oid = c.relnamespace
             WHERE n.nspname = $1
               AND c.relkind IN ('r', 'p')
+              AND NOT c.relispartition
             ORDER BY c.relname
             """, params: [schemaFilter])
-        let tables = result.rows.compactMap { row -> TableInfo? in
+        return result.rows.compactMap { row -> TableInfo? in
             guard let name = row.first?.stringValue else { return nil }
             let count = row.count > 1 ? row[1].intValue : nil
             return TableInfo(name: name, schema: schemaFilter, type: .table, estimatedRowCount: count)
         }
-        logger.debug("Loaded tables", metadata: ["schema": "\(schemaFilter)", "count": "\(tables.count)"])
-        return tables
     }
 
     func listViews(schema: String?) async throws -> [ViewInfo] {

--- a/macos/Tests/GridexTests/PostgreSQLAdapterIntegrationTests.swift
+++ b/macos/Tests/GridexTests/PostgreSQLAdapterIntegrationTests.swift
@@ -205,4 +205,43 @@ final class PostgreSQLAdapterIntegrationTests: XCTestCase {
             }
         }
     }
+
+    func test_listTables_usesPgCatalogOnHighGoSecure() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let host = env["GRIDEX_HIGHGO_HOST"],
+              let port = Int(env["GRIDEX_HIGHGO_PORT"] ?? ""),
+              let database = env["GRIDEX_HIGHGO_DATABASE"],
+              let username = env["GRIDEX_HIGHGO_USER"],
+              let password = env["GRIDEX_HIGHGO_PASSWORD"] else {
+            throw XCTSkip("Set GRIDEX_HIGHGO_* to run the HighGo Secure catalog regression test")
+        }
+
+        let cfg = ConnectionConfig(
+            id: UUID(),
+            name: "highgo-catalog-regression",
+            databaseType: .postgresql,
+            host: host,
+            port: port,
+            database: database,
+            username: username,
+            sslEnabled: false,
+            sslMode: .disabled
+        )
+        let adapter = PostgreSQLAdapter()
+        try await adapter.connect(config: cfg, password: password)
+
+        let tables: [TableInfo]
+        do {
+            tables = try await adapter.listTables(schema: "public")
+            try await adapter.disconnect()
+        } catch {
+            try? await adapter.disconnect()
+            throw error
+        }
+
+        let names = tables.map(\.name)
+        XCTAssertEqual(names.count, Set(names).count, "HighGo information_schema.tables can duplicate rows; listTables must return unique physical tables")
+        XCTAssertEqual(names.filter { $0 == "app_view" }.count, 1)
+        XCTAssertTrue(names.contains("hg_t_audit_log"), "pg_class-backed listTables should include physical tables hidden by information_schema.tables")
+    }
 }

--- a/macos/Tests/GridexTests/PostgreSQLAdapterIntegrationTests.swift
+++ b/macos/Tests/GridexTests/PostgreSQLAdapterIntegrationTests.swift
@@ -260,4 +260,50 @@ final class PostgreSQLAdapterIntegrationTests: XCTestCase {
             "pg_class-backed listTables should include HighGo-managed physical tables (hg_*) that information_schema.tables can hide"
         )
     }
+
+    // MARK: - Vanilla PG regression — partition children must not surface as siblings
+
+    // Declarative partitioning (PG 11+): a partition child has relkind='r' and
+    // relispartition=true. The parent (relkind='p') already represents its
+    // children's data in the UI, so leaking children would double-count rows
+    // and clutter the sidebar. The original information_schema.tables query
+    // returned only 'BASE TABLE' parents; switching to pg_class introduced
+    // the leak unless we also filter `NOT relispartition`.
+    func test_listTables_excludesPartitionChildren_onVanillaPG() async throws {
+        try skipIfNoServer(port: 55434)
+
+        let cfg = makeBaseConfig(host: "127.0.0.1", port: 55434, sslMode: .disabled)
+        let adapter = PostgreSQLAdapter()
+        try await adapter.connect(config: cfg, password: nil)
+
+        // Clean previous fixtures, then create a partitioned table + one partition.
+        let prefix = "gridex_part_test_\(UUID().uuidString.prefix(8).lowercased())"
+        let plain = "\(prefix)_plain"
+        let parent = "\(prefix)_parent"
+        let child = "\(prefix)_p1"
+        do {
+            _ = try await adapter.executeRaw(sql: "CREATE TABLE \(plain) (id int)")
+            _ = try await adapter.executeRaw(sql: "CREATE TABLE \(parent) (id int) PARTITION BY RANGE (id)")
+            _ = try await adapter.executeRaw(sql: "CREATE TABLE \(child) PARTITION OF \(parent) FOR VALUES FROM (0) TO (100)")
+
+            let names = try await adapter.listTables(schema: "public").map(\.name)
+
+            XCTAssertTrue(names.contains(plain),
+                "ordinary table \(plain) must appear")
+            XCTAssertTrue(names.contains(parent),
+                "partitioned-table parent \(parent) must appear")
+            XCTAssertFalse(names.contains(child),
+                "partition child \(child) must NOT appear as a sibling — it would double-count the parent's data")
+        } catch {
+            // Best-effort cleanup, then rethrow.
+            _ = try? await adapter.executeRaw(sql: "DROP TABLE IF EXISTS \(parent) CASCADE")
+            _ = try? await adapter.executeRaw(sql: "DROP TABLE IF EXISTS \(plain)")
+            try? await adapter.disconnect()
+            throw error
+        }
+
+        _ = try? await adapter.executeRaw(sql: "DROP TABLE IF EXISTS \(parent) CASCADE")
+        _ = try? await adapter.executeRaw(sql: "DROP TABLE IF EXISTS \(plain)")
+        try await adapter.disconnect()
+    }
 }

--- a/macos/Tests/GridexTests/PostgreSQLAdapterIntegrationTests.swift
+++ b/macos/Tests/GridexTests/PostgreSQLAdapterIntegrationTests.swift
@@ -206,6 +206,20 @@ final class PostgreSQLAdapterIntegrationTests: XCTestCase {
         }
     }
 
+    // MARK: - HighGo Secure regressions
+
+    // Regression test for HighGo Secure 4.5+: information_schema.tables can return
+    // duplicate rows for the same physical table, which made the macOS sidebar
+    // render repeated names. listTables must dedupe by reading pg_class directly.
+    //
+    // Target instance requirements:
+    //   - Must allow non-SSL connections (test connects with sslMode = .disabled).
+    //   - Schema `public` must contain at least one user-visible table whose name
+    //     starts with `hg_` (e.g. the HighGo audit module's `hg_t_audit_log`),
+    //     i.e. the HighGo audit module must be enabled.
+    //
+    // Run with: GRIDEX_HIGHGO_HOST=... GRIDEX_HIGHGO_PORT=... GRIDEX_HIGHGO_DATABASE=...
+    //            GRIDEX_HIGHGO_USER=... GRIDEX_HIGHGO_PASSWORD=... swift test ...
     func test_listTables_usesPgCatalogOnHighGoSecure() async throws {
         let env = ProcessInfo.processInfo.environment
         guard let host = env["GRIDEX_HIGHGO_HOST"],
@@ -241,7 +255,9 @@ final class PostgreSQLAdapterIntegrationTests: XCTestCase {
 
         let names = tables.map(\.name)
         XCTAssertEqual(names.count, Set(names).count, "HighGo information_schema.tables can duplicate rows; listTables must return unique physical tables")
-        XCTAssertEqual(names.filter { $0 == "app_view" }.count, 1)
-        XCTAssertTrue(names.contains("hg_t_audit_log"), "pg_class-backed listTables should include physical tables hidden by information_schema.tables")
+        XCTAssertTrue(
+            names.contains(where: { $0.hasPrefix("hg_") }),
+            "pg_class-backed listTables should include HighGo-managed physical tables (hg_*) that information_schema.tables can hide"
+        )
     }
 }


### PR DESCRIPTION
## Overview

Fixes duplicate table names in the macOS sidebar when connecting to HighGo Secure 4.5+ in PostgreSQL mode. On that distribution, `information_schema.tables` returns multiple rows for the same physical table, which made the sidebar render repeated entries and caused name-based selection to highlight every duplicate at once.

## Bug screenshot

<img width="4994" height="2820" alt="image" src="https://github.com/user-attachments/assets/c33ea3fb-17d7-43d6-9233-4dc6d9457401" />


In the sidebar `app_view` is rendered 19 times, `app_view_imr` and `app_view_scope_dict` 5 times each — the physical tables actually exist only once.

## Root cause

`information_schema.tables` is a SQL-standard metadata view whose implementation differs across PG distributions. HighGo Secure 4.5+ with the audit module enabled emits duplicate rows. This is the project's §3 DON'T #1 anti-pattern (see the earlier sibling fix `d6e51b3` that did the same shift for `listSchemas`).

## Fix

`PostgreSQLAdapter.listTables` now queries `pg_class` + `pg_namespace` directly, with `relkind IN ('r', 'p')` covering ordinary and partitioned tables — aligned with `listSchemas`:

- `NULLIF(c.reltuples::bigint, -1)` replaces the legacy `-1` fallback, so tables that have never been ANALYZEd surface as NULL instead of `-1`.
- A single JOIN replaces the previous correlated subquery, saving one catalog lookup per row.

## Tests

Adds `test_listTables_usesPgCatalogOnHighGoSecure` in `PostgreSQLAdapterIntegrationTests.swift`:

- Gated on `GRIDEX_HIGHGO_*` env vars; CI skips by default.
- Primary regression assertion: `listTables` returns a set of unique names.
- Secondary assertion: at least one HighGo-managed table whose name starts with `hg_` (relaxed from a fixed table name to tolerate audit-module deployment differences).
- Fixture expectations, SSL-mode requirement, and the run command are documented in the test header.

## Test plan

- [x] \`swift build\` passes (no new warnings)
- [x] \`swift build --target GridexTests\` passes
- [x] Debug \`Gridex.app\` build succeeds (\`./scripts/build-app.sh\`)
- [ ] Run \`swift test --filter test_listTables_usesPgCatalogOnHighGoSecure\` against a HighGo Secure 4.5+ instance (needs \`GRIDEX_HIGHGO_*\`)
- [ ] Connect the macOS sidebar to a HighGo instance and confirm table names no longer duplicate
- [ ] Smoke-test against a vanilla PostgreSQL instance to confirm no regression