### PR TITLE
chore(release): bump version to 0.0.14

### DIFF
--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -32,9 +32,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.13</string>
+	<string>0.0.14</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Routine version bump after PR #47 merge.

Ships:

- **PR #47** — `listTables` switched from `information_schema.tables` to `pg_class` to dedupe HighGo Secure rows (cyenxchen).
- **Partition fix** on top of #47 — `AND NOT c.relispartition` filter restoring the original semantics for declarative-partitioned tables, plus a regression test (`test_listTables_excludesPartitionChildren_onVanillaPG`).

Single-file change: `Info.plist` `CFBundleShortVersionString` and `CFBundleVersion` advanced together (`0.0.13 → 0.0.14`).

## Out of scope (will follow up)

`listViews` and `primaryKeyColumns` in `PostgreSQLAdapter.swift` still query `information_schema.*` — same HighGo-dup risk class. A separate PR for that is queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)