### PR TITLE
feat(ai): add ChatGPT subscription provider via Codex CLI OAuth flow

### DIFF
--- a/macos/App/DependencyInjection/DependencyContainer.swift
+++ b/macos/App/DependencyInjection/DependencyContainer.swift
@@ -86,14 +86,29 @@ final class DependencyContainer {
 
     lazy var providerRegistry = ProviderRegistry()
 
+    /// OAuth service for ChatGPT-subscription providers. Holds no state on the
+    /// MainActor; callers from `ProviderRegistry` (an actor) reach it through
+    /// the container intentionally — provider-construction happens before the
+    /// service is invoked.
+    lazy var chatGPTOAuthService: ChatGPTOAuthService = ChatGPTOAuthService(keychainService: keychainService)
+
     /// Load all enabled providers from persistence and register them with the registry.
     /// Call once at app startup. Safe to call again after config changes.
     func bootstrapProviderRegistry() async {
         await providerRegistry.removeAll()
         let configs = (try? await llmProviderRepository.fetchAll()) ?? []
         for config in configs where config.enabled {
-            let apiKey = (try? keychainService.load(key: "ai.apikey.\(config.id.uuidString)")) ?? ""
-            await providerRegistry.register(config, apiKey: apiKey)
+            switch config.type {
+            case .chatGPT:
+                // No long-lived API key — the bundle lives in Keychain under
+                // `ai.chatgpt.tokens.<uuid>`. Skip registration if the user
+                // added the provider but never completed sign-in.
+                guard (try? keychainService.loadChatGPTTokens(providerId: config.id)) != nil else { continue }
+                await providerRegistry.register(config, apiKey: "", chatGPTOAuthService: chatGPTOAuthService)
+            default:
+                let apiKey = (try? keychainService.load(key: "ai.apikey.\(config.id.uuidString)")) ?? ""
+                await providerRegistry.register(config, apiKey: apiKey)
+            }
         }
     }
 

--- a/macos/Core/Enums/ProviderType.swift
+++ b/macos/Core/Enums/ProviderType.swift
@@ -11,6 +11,9 @@ enum ProviderType: String, Codable, Sendable, CaseIterable, Identifiable {
     case gemini
     case ollama
 
+    // Subscription-based access via OAuth (own provider class)
+    case chatGPT          = "chatgpt"
+
     // OpenAI-compatible family (all use OpenAIProvider)
     case openAI           = "openai"
     case azureOpenAI      = "azure-openai"
@@ -35,6 +38,7 @@ enum ProviderType: String, Codable, Sendable, CaseIterable, Identifiable {
         case .anthropic:         return "Anthropic (Claude)"
         case .gemini:            return "Google Gemini"
         case .ollama:            return "Ollama (Local)"
+        case .chatGPT:           return "OpenAI (Sign in)"
         case .openAI:            return "OpenAI"
         case .azureOpenAI:       return "Azure OpenAI"
         case .groq:              return "Groq"
@@ -57,6 +61,7 @@ enum ProviderType: String, Codable, Sendable, CaseIterable, Identifiable {
         case .anthropic: return .anthropic
         case .gemini:    return .gemini
         case .ollama:    return .local
+        case .chatGPT:   return .subscription
         case .openAI, .azureOpenAI, .groq, .deepseek, .mistral, .xAI,
              .perplexity, .openRouter, .together, .fireworks, .dashscope,
              .dashscopeCoding, .openAICompatible:
@@ -68,6 +73,7 @@ enum ProviderType: String, Codable, Sendable, CaseIterable, Identifiable {
         case anthropic     = "Anthropic"
         case gemini        = "Google"
         case openAICompat  = "OpenAI-Compatible"
+        case subscription  = "Subscription / OAuth"
         case local         = "Local"
     }
 
@@ -76,6 +82,7 @@ enum ProviderType: String, Codable, Sendable, CaseIterable, Identifiable {
         case .anthropic:         return "https://api.anthropic.com/v1"
         case .gemini:            return "https://generativelanguage.googleapis.com/v1beta/openai"
         case .ollama:            return "http://localhost:11434"
+        case .chatGPT:           return "https://chatgpt.com/backend-api/codex"
         case .openAI:            return "https://api.openai.com/v1"
         case .azureOpenAI:       return "https://YOUR-RESOURCE.openai.azure.com/openai"
         case .groq:              return "https://api.groq.com/openai/v1"
@@ -97,6 +104,7 @@ enum ProviderType: String, Codable, Sendable, CaseIterable, Identifiable {
         case .anthropic:         return "claude-sonnet-4-6"
         case .gemini:            return "gemini-2.5-flash"
         case .ollama:            return "llama3"
+        case .chatGPT:           return "gpt-5.4"
         case .openAI:            return "gpt-4o"
         case .azureOpenAI:       return "gpt-4o"
         case .groq:              return "llama-3.3-70b-versatile"
@@ -114,7 +122,9 @@ enum ProviderType: String, Codable, Sendable, CaseIterable, Identifiable {
     }
 
     var requiresAPIKey: Bool {
-        self != .ollama
+        // .chatGPT uses OAuth tokens (Keychain blob), not a long-lived API key.
+        // .ollama is local and unauthenticated.
+        self != .ollama && self != .chatGPT
     }
 
     var allowsPrivateHosts: Bool {
@@ -136,6 +146,7 @@ enum ProviderType: String, Codable, Sendable, CaseIterable, Identifiable {
         case .anthropic:                     return "a.circle.fill"
         case .gemini:                        return "g.circle.fill"
         case .ollama:                        return "desktopcomputer"
+        case .chatGPT:                       return "person.crop.circle.badge.checkmark"
         case .openAI:                        return "bubble.left.and.text.bubble.right.fill"
         case .azureOpenAI:                   return "cloud.fill"
         case .groq:                          return "bolt.circle.fill"
@@ -157,6 +168,11 @@ enum ProviderType: String, Codable, Sendable, CaseIterable, Identifiable {
         case .anthropic:         return ["claude-sonnet-4-6", "claude-haiku-4-5-20251001", "claude-opus-4-6"]
         case .gemini:            return ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash"]
         case .ollama:            return ["llama3", "codellama", "mistral"]
+        // ChatGPT model slugs are owned by the Responses API and the only
+        // authoritative list comes from `/backend-api/codex/models`. Hard-coding
+        // names here would invent IDs that don't exist server-side; if the live
+        // fetch fails the user must type a slug manually.
+        case .chatGPT:           return []
         case .openAI:            return ["gpt-4o", "gpt-4o-mini", "o1", "o1-mini"]
         case .azureOpenAI:       return ["gpt-4o", "gpt-4o-mini"]
         case .groq:              return ["llama-3.3-70b-versatile", "llama-3.1-8b-instant", "mixtral-8x7b-32768"]

--- a/macos/Core/Enums/ProviderType.swift
+++ b/macos/Core/Enums/ProviderType.swift
@@ -104,7 +104,13 @@ enum ProviderType: String, Codable, Sendable, CaseIterable, Identifiable {
         case .anthropic:         return "claude-sonnet-4-6"
         case .gemini:            return "gemini-2.5-flash"
         case .ollama:            return "llama3"
-        case .chatGPT:           return "gpt-5.4"
+        // ChatGPT model slugs are owned by `/backend-api/codex/models`. The
+        // authoritative list comes from the live fetch after sign-in;
+        // `gpt-5-codex` is Codex CLI's own default and the safest known-real
+        // slug to use as a stop-gap until the live `/models` call resolves.
+        // (Earlier value `gpt-5.4` was invented and produced HTTP 400 on
+        // first request before the picker had a chance to update.)
+        case .chatGPT:           return "gpt-5-codex"
         case .openAI:            return "gpt-4o"
         case .azureOpenAI:       return "gpt-4o"
         case .groq:              return "llama-3.3-70b-versatile"

--- a/macos/Core/Enums/ProviderType.swift
+++ b/macos/Core/Enums/ProviderType.swift
@@ -104,13 +104,7 @@ enum ProviderType: String, Codable, Sendable, CaseIterable, Identifiable {
         case .anthropic:         return "claude-sonnet-4-6"
         case .gemini:            return "gemini-2.5-flash"
         case .ollama:            return "llama3"
-        // ChatGPT model slugs are owned by `/backend-api/codex/models`. The
-        // authoritative list comes from the live fetch after sign-in;
-        // `gpt-5-codex` is Codex CLI's own default and the safest known-real
-        // slug to use as a stop-gap until the live `/models` call resolves.
-        // (Earlier value `gpt-5.4` was invented and produced HTTP 400 on
-        // first request before the picker had a chance to update.)
-        case .chatGPT:           return "gpt-5-codex"
+        case .chatGPT:           return "gpt-5.4"
         case .openAI:            return "gpt-4o"
         case .azureOpenAI:       return "gpt-4o"
         case .groq:              return "llama-3.3-70b-versatile"

--- a/macos/Core/Models/AI/ChatGPTTokenBundle.swift
+++ b/macos/Core/Models/AI/ChatGPTTokenBundle.swift
@@ -1,0 +1,60 @@
+// ChatGPTTokenBundle.swift
+// Gridex
+//
+// OAuth token bundle persisted in Keychain for the .chatGPT provider type.
+// Stored as JSON under key "ai.chatgpt.tokens.<provider-uuid>" — a single blob
+// so refresh writes are atomic.
+
+import Foundation
+
+struct ChatGPTTokenBundle: Codable, Sendable, Equatable {
+    /// JWT — short-lived, used as `Authorization: Bearer ...` against
+    /// chatgpt.com/backend-api/codex.
+    var accessToken: String
+
+    /// JWT — long-lived, used to mint new access tokens. Server may rotate
+    /// this on refresh; callers must merge the new value over the old bundle
+    /// (and keep the old refresh_token if the response omits it).
+    var refreshToken: String
+
+    /// JWT — carries claims (`chatgpt_account_id`, `email`, `chatgpt_plan_type`).
+    /// Persisted so we can re-derive identity without re-querying the server.
+    var idToken: String
+
+    /// Mirrors the `chatgpt_account_id` claim from `idToken`. Sent as the
+    /// `ChatGPT-Account-ID` header on backend calls when present.
+    var accountId: String?
+
+    /// Mirrors the `email` claim. UI-only, for "Signed in as ..." display.
+    var email: String?
+
+    /// Mirrors the `chatgpt_plan_type` claim (e.g. "plus", "pro"). UI-only.
+    var planType: String?
+
+    /// Wall-clock time the bundle was minted (sign-in or last refresh).
+    var obtainedAt: Date
+
+    /// Reserved for future migrations if OpenAI changes the id_token claim
+    /// shape. v1 = the layout above.
+    var schemaVersion: Int
+
+    init(
+        accessToken: String,
+        refreshToken: String,
+        idToken: String,
+        accountId: String? = nil,
+        email: String? = nil,
+        planType: String? = nil,
+        obtainedAt: Date = Date(),
+        schemaVersion: Int = 1
+    ) {
+        self.accessToken   = accessToken
+        self.refreshToken  = refreshToken
+        self.idToken       = idToken
+        self.accountId     = accountId
+        self.email         = email
+        self.planType      = planType
+        self.obtainedAt    = obtainedAt
+        self.schemaVersion = schemaVersion
+    }
+}

--- a/macos/Data/Keychain/KeychainService.swift
+++ b/macos/Data/Keychain/KeychainService.swift
@@ -13,6 +13,13 @@ protocol KeychainServiceProtocol: Sendable {
     func load(key: String) throws -> String?
     func delete(key: String) throws
     func update(key: String, value: String) throws
+
+    // ChatGPT OAuth bundle (per-provider). Implemented in terms of save/load/delete
+    // above, but lives on the protocol so call sites holding only the protocol
+    // type (e.g. ProviderEditSheet, SettingsView) can use them.
+    func saveChatGPTTokens(providerId: UUID, bundle: ChatGPTTokenBundle) throws
+    func loadChatGPTTokens(providerId: UUID) throws -> ChatGPTTokenBundle?
+    func deleteChatGPTTokens(providerId: UUID) throws
 }
 
 final class KeychainService: KeychainServiceProtocol, Sendable {
@@ -206,5 +213,39 @@ final class KeychainService: KeychainServiceProtocol, Sendable {
 
     func loadAPIKey(provider: String) throws -> String? {
         try load(key: "ai.apikey.\(provider)")
+    }
+
+    // MARK: - ChatGPT OAuth tokens
+    //
+    // Stored as a JSON-encoded `ChatGPTTokenBundle` under a per-provider key.
+    // Single blob keeps refresh writes atomic — partial updates after a crash
+    // are not possible.
+
+    private func chatGPTTokensKey(_ providerId: UUID) -> String {
+        "ai.chatgpt.tokens.\(providerId.uuidString)"
+    }
+
+    func saveChatGPTTokens(providerId: UUID, bundle: ChatGPTTokenBundle) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(bundle)
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw GridexError.keychainError("Failed to encode ChatGPT token bundle")
+        }
+        try save(key: chatGPTTokensKey(providerId), value: json)
+    }
+
+    func loadChatGPTTokens(providerId: UUID) throws -> ChatGPTTokenBundle? {
+        guard let json = try load(key: chatGPTTokensKey(providerId)) else { return nil }
+        guard let data = json.data(using: .utf8) else {
+            throw GridexError.keychainError("ChatGPT token bundle keychain blob is not valid UTF-8")
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(ChatGPTTokenBundle.self, from: data)
+    }
+
+    func deleteChatGPTTokens(providerId: UUID) throws {
+        try delete(key: chatGPTTokensKey(providerId))
     }
 }

--- a/macos/Presentation/Views/AIChat/AIChatView.swift
+++ b/macos/Presentation/Views/AIChat/AIChatView.swift
@@ -4,6 +4,7 @@
 // SwiftUI AI chat panel with streaming responses.
 
 import SwiftUI
+import os
 
 // Observable message class — mutations don't trigger ForEach diffing
 final class ChatDisplayMessage: ObservableObject, Identifiable {
@@ -23,6 +24,8 @@ final class ChatDisplayMessage: ObservableObject, Identifiable {
 }
 
 struct AIChatView: View {
+    private static let log = Logger(subsystem: "com.gridex.gridex", category: "AIChat")
+
     @EnvironmentObject private var appState: AppState
     @AppStorage("ai.activeProviderID") private var activeProviderID: String = ""
     @AppStorage("ai.activeModel")      private var activeModel: String = ""
@@ -605,17 +608,25 @@ struct AIChatView: View {
     private func refreshAPIKeyState() {
         // Multi-provider path: an active provider ID is set.
         if !activeProviderID.isEmpty, let uuid = UUID(uuidString: activeProviderID) {
-            let key = try? DependencyContainer.shared.keychainService.load(key: "ai.apikey.\(uuid.uuidString)")
-            // Ollama has no key but is still usable → treat presence of an active ID as ready
-            // unless we can verify the config requires a key and none is set.
             Task {
                 let config = try? await DependencyContainer.shared.llmProviderRepository.fetchByID(uuid)
-                await MainActor.run {
-                    if let config, config.enabled {
-                        apiKeyLoaded = !config.type.requiresAPIKey || (key != nil && !key!.isEmpty)
-                    } else {
-                        apiKeyLoaded = false
+                let ready: Bool
+                if let config, config.enabled {
+                    switch config.type {
+                    case .chatGPT:
+                        ready = (try? DependencyContainer.shared.keychainService
+                            .loadChatGPTTokens(providerId: uuid)) != nil
+                    default:
+                        let key = try? DependencyContainer.shared.keychainService.load(key: "ai.apikey.\(uuid.uuidString)")
+                        // Ollama has no key but is still usable; API-key providers
+                        // need a non-empty stored key.
+                        ready = !config.type.requiresAPIKey || (key != nil && !key!.isEmpty)
                     }
+                } else {
+                    ready = false
+                }
+                await MainActor.run {
+                    apiKeyLoaded = ready
                 }
             }
             return
@@ -638,7 +649,23 @@ struct AIChatView: View {
                 key: ProviderEditSheet.keychainKey(id: uuid)
             )) ?? ""
             if config.type.requiresAPIKey, apiKey.isEmpty { return nil }
-            let service = ProviderFactory.make(config: config, apiKey: apiKey)
+            // ChatGPT (Sign in) requires the OAuth service; if not signed in,
+            // the Keychain bundle is missing — fail clearly instead of crashing.
+            if config.type == .chatGPT {
+                guard (try? DependencyContainer.shared.keychainService
+                    .loadChatGPTTokens(providerId: uuid)) != nil else {
+                    Self.log.notice("Active ChatGPT provider \(uuid.uuidString, privacy: .public) has no token bundle; marking AI chat not ready")
+                    await MainActor.run {
+                        apiKeyLoaded = false
+                    }
+                    return nil
+                }
+            }
+            let service = ProviderFactory.make(
+                config: config,
+                apiKey: apiKey,
+                chatGPTOAuthService: DependencyContainer.shared.chatGPTOAuthService
+            )
             let modelToUse = activeModel.isEmpty ? config.model : activeModel
             return (service, modelToUse)
         }
@@ -739,6 +766,14 @@ struct AIChatView: View {
                 )
                 for try await token in stream {
                     assistantMsg.content += token
+                }
+            } catch GridexError.aiAPIKeyMissing {
+                await MainActor.run {
+                    apiKeyLoaded = false
+                    refreshAPIKeyState()
+                }
+                if assistantMsg.content.isEmpty {
+                    assistantMsg.content = "Error: \(GridexError.aiAPIKeyMissing.localizedDescription)"
                 }
             } catch {
                 if assistantMsg.content.isEmpty {

--- a/macos/Presentation/Windows/Settings/ProviderEditSheet.swift
+++ b/macos/Presentation/Windows/Settings/ProviderEditSheet.swift
@@ -5,6 +5,7 @@
 // API key lives in Keychain keyed by the config UUID (ai.apikey.<uuid>), never
 // in SwiftData.
 
+import os
 import SwiftUI
 
 struct ProviderEditSheet: View {
@@ -13,10 +14,31 @@ struct ProviderEditSheet: View {
     /// Called when the sheet saves successfully. Parent should reload list.
     let onSaved: (ProviderConfig) -> Void
 
+    init(editing: ProviderConfig?, onSaved: @escaping (ProviderConfig) -> Void) {
+        self.editing = editing
+        self.onSaved = onSaved
+
+        if let editing {
+            _resolvedId = State(initialValue: editing.id)
+            _name = State(initialValue: editing.name)
+            _type = State(initialValue: editing.type)
+            _apiBase = State(initialValue: editing.apiBase ?? editing.type.defaultBaseURL)
+            _model = State(initialValue: editing.model)
+            _enabled = State(initialValue: editing.enabled)
+        }
+    }
+
     @Environment(\.dismiss) private var dismiss
+
+    private static let log = Logger(subsystem: "com.gridex.gridex", category: "ProviderEditSheet")
 
     private let keychain: KeychainServiceProtocol = DependencyContainer.shared.keychainService
     private let repository: any LLMProviderRepository = DependencyContainer.shared.llmProviderRepository
+
+    /// Provider id used by both the OAuth flow (`ai.chatgpt.tokens.<id>` keychain
+    /// key) and the eventual SwiftData row. Generated eagerly so a Sign-in click
+    /// on a brand-new provider persists tokens under the id we'll reuse on Save.
+    @State private var resolvedId: UUID = UUID()
 
     @State private var name: String = ""
     @State private var type: ProviderType = .anthropic
@@ -33,6 +55,18 @@ struct ProviderEditSheet: View {
     @State private var urlError: String?
     @State private var saveError: String?
 
+    // ChatGPT OAuth state (only used when type == .chatGPT)
+    @State private var chatGPTStatus: ChatGPTOAuthService.SignInStatus = .signedOut
+    @State private var isSigningIn: Bool = false
+    @State private var signInError: String?
+
+    /// True when this session may produce a Keychain token bundle that hasn't
+    /// been confirmed by Save. Add mode and edits that switch a non-ChatGPT row
+    /// to ChatGPT both need rollback on dismiss; editing an existing ChatGPT row
+    /// is exempt because the bundle already belongs to that persisted provider.
+    @State private var dirtyChatGPTSignIn: Bool = false
+    @State private var chatGPTSignInTask: Task<Void, Never>?
+
     enum FetchResult: Equatable {
         case none
         case loaded(Int)
@@ -47,10 +81,19 @@ struct ProviderEditSheet: View {
 
     private var isEdit: Bool { editing != nil }
     private var canSave: Bool {
-        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-        urlError == nil &&
-        (!type.requiresAPIKey || !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) &&
-        !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let nameOK  = !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let modelOK = !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+        if type == .chatGPT {
+            if case .signedIn = chatGPTStatus {
+                return nameOK && modelOK
+            }
+            return false
+        }
+        return nameOK
+            && urlError == nil
+            && (!type.requiresAPIKey || !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            && modelOK
     }
 
     var body: some View {
@@ -63,6 +106,23 @@ struct ProviderEditSheet: View {
         }
         .frame(width: 560, height: 540)
         .onAppear(perform: load)
+        .onDisappear {
+            let pendingSignIn = chatGPTSignInTask
+            chatGPTSignInTask = nil
+            pendingSignIn?.cancel()
+
+            // Add-mode sign-in may still complete after the sheet closes. Wait
+            // for cancellation/completion, then clear any bundle that may have
+            // been written under an unsaved provider id.
+            guard dirtyChatGPTSignIn else { return }
+            let pid = resolvedId
+            Task {
+                if let pendingSignIn {
+                    await pendingSignIn.value
+                }
+                try? await DependencyContainer.shared.chatGPTOAuthService.signOut(providerId: pid)
+            }
+        }
     }
 
     // MARK: - Header
@@ -100,20 +160,58 @@ struct ProviderEditSheet: View {
                 .onChange(of: type) { _, newType in applyTypeDefaults(newType) }
             }
 
-            Section("Endpoint") {
-                TextField("API Base URL", text: $apiBase)
-                    .textFieldStyle(.roundedBorder)
-                    .onChange(of: apiBase) { _, newValue in validateURL(newValue) }
-                if let urlError {
-                    Text(urlError).font(.system(size: 11)).foregroundStyle(.red)
-                }
-                if type.requiresAPIKey {
-                    SecureField("API Key", text: $apiKey)
+            Section(type == .chatGPT ? "Authentication" : "Endpoint") {
+                if type == .chatGPT {
+                    chatGPTAuthBlock
+                } else {
+                    TextField("API Base URL", text: $apiBase)
                         .textFieldStyle(.roundedBorder)
+                        .onChange(of: apiBase) { _, newValue in validateURL(newValue) }
+                    if let urlError {
+                        Text(urlError).font(.system(size: 11)).foregroundStyle(.red)
+                    }
+                    if type.requiresAPIKey {
+                        SecureField("API Key", text: $apiKey)
+                            .textFieldStyle(.roundedBorder)
+                    }
                 }
             }
 
+            if shouldShowModelSection {
+                modelSection
+            }
+
             Section {
+                Toggle("Enabled", isOn: $enabled)
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private var shouldShowModelSection: Bool {
+        guard type == .chatGPT else { return true }
+        if case .signedIn = chatGPTStatus {
+            return true
+        }
+        return false
+    }
+
+    private var modelSection: some View {
+        Section {
+            if type == .chatGPT {
+                if !availableModels.isEmpty {
+                    Picker("Model", selection: $model) {
+                        Text("Select a model").tag("")
+                        if !model.isEmpty, !availableModels.contains(where: { $0.id == model }) {
+                            Text(model).tag(model)
+                        }
+                        ForEach(availableModels) { m in
+                            Text(m.name).tag(m.id)
+                        }
+                    }
+                    .onChange(of: model) { _, _ in testResult = .none }
+                }
+            } else {
                 if !availableModels.isEmpty {
                     Picker("Available", selection: $model) {
                         ForEach(availableModels) { m in
@@ -131,72 +229,78 @@ struct ProviderEditSheet: View {
                         }
                         testResult = .none
                     }
-            } header: {
-                HStack {
-                    Text("Model")
-                    Spacer()
-                    if isLoadingModels { ProgressView().controlSize(.small) }
-                }
-            } footer: {
-                switch fetchResult {
-                case .none:
-                    Text("Click **Fetch Models** below to load the list from the API, or type a model ID manually.")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                case .loaded(let count) where count > 0:
-                    Text("\(count) models loaded from API.")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.green)
-                case .loaded:
-                    Text("Endpoint responded but returned no models — type a model ID manually.")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.orange)
-                case .failure(let msg):
-                    Text(msg)
-                        .font(.system(size: 11))
-                        .foregroundStyle(.red)
-                }
             }
-
-            Section {
-                Toggle("Enabled", isOn: $enabled)
+        } header: {
+            HStack {
+                Text("Model")
+                Spacer()
+                if isLoadingModels { ProgressView().controlSize(.small) }
             }
+        } footer: {
+            modelSectionFooter
         }
-        .formStyle(.grouped)
+    }
+
+    @ViewBuilder
+    private var modelSectionFooter: some View {
+        switch fetchResult {
+        case .none:
+            if type != .chatGPT {
+                Text("Click **Fetch Models** below to load the list from the API, or type a model ID manually.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+        case .loaded(let count) where count > 0:
+            Text("\(count) models loaded from API.")
+                .font(.system(size: 11))
+                .foregroundStyle(.green)
+        case .loaded:
+            Text("Endpoint responded but returned no models.")
+                .font(.system(size: 11))
+                .foregroundStyle(.orange)
+        case .failure(let msg):
+            Text(msg)
+                .font(.system(size: 11))
+                .foregroundStyle(.red)
+        }
     }
 
     // MARK: - Footer
 
     private var footer: some View {
         HStack(spacing: 8) {
-            Button(action: fetchModels) {
-                HStack(spacing: 6) {
-                    if isLoadingModels { ProgressView().controlSize(.small) }
-                    Text("Fetch Models")
+            // Fetch Models / Test only apply to API-key providers — ChatGPT
+            // uses OAuth and populates models implicitly after sign-in.
+            if type != .chatGPT {
+                Button(action: fetchModels) {
+                    HStack(spacing: 6) {
+                        if isLoadingModels { ProgressView().controlSize(.small) }
+                        Text("Fetch Models")
+                    }
                 }
-            }
-            .disabled(isLoadingModels || (type.requiresAPIKey && apiKey.isEmpty) || urlError != nil)
+                .disabled(isLoadingModels || (type.requiresAPIKey && apiKey.isEmpty) || urlError != nil)
 
-            Button(action: testConnection) {
-                HStack(spacing: 6) {
-                    if isTesting { ProgressView().controlSize(.small) }
-                    Text("Test")
+                Button(action: testConnection) {
+                    HStack(spacing: 6) {
+                        if isTesting { ProgressView().controlSize(.small) }
+                        Text("Test")
+                    }
                 }
-            }
-            .disabled(isTesting
-                      || (type.requiresAPIKey && apiKey.isEmpty)
-                      || urlError != nil
-                      || model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-            .help("Send a 1-token request to verify the key + URL + model combination")
+                .disabled(isTesting
+                          || (type.requiresAPIKey && apiKey.isEmpty)
+                          || urlError != nil
+                          || model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .help("Send a 1-token request to verify the key + URL + model combination")
 
-            switch testResult {
-            case .none: EmptyView()
-            case .success:
-                Label("Connected", systemImage: "checkmark.circle.fill")
-                    .foregroundStyle(.green).font(.system(size: 12))
-            case .failure(let msg):
-                Label(msg, systemImage: "xmark.circle.fill")
-                    .foregroundStyle(.red).font(.system(size: 12)).lineLimit(1)
+                switch testResult {
+                case .none: EmptyView()
+                case .success:
+                    Label("Connected", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green).font(.system(size: 12))
+                case .failure(let msg):
+                    Label(msg, systemImage: "xmark.circle.fill")
+                        .foregroundStyle(.red).font(.system(size: 12)).lineLimit(1)
+                }
             }
 
             Spacer()
@@ -220,12 +324,13 @@ struct ProviderEditSheet: View {
 
     private func load() {
         if let editing {
-            name    = editing.name
-            type    = editing.type
-            apiBase = editing.apiBase ?? editing.type.defaultBaseURL
-            model   = editing.model
-            enabled = editing.enabled
-            apiKey  = (try? keychain.load(key: Self.keychainKey(id: editing.id))) ?? ""
+            if editing.type == .chatGPT {
+                // No API key for OAuth providers; status comes from the keychain bundle.
+                apiKey = ""
+                Task { await refreshChatGPTStatus() }
+            } else {
+                apiKey = (try? keychain.load(key: Self.keychainKey(id: editing.id))) ?? ""
+            }
         } else {
             applyTypeDefaults(type)
         }
@@ -233,6 +338,21 @@ struct ProviderEditSheet: View {
     }
 
     private func applyTypeDefaults(_ newType: ProviderType) {
+        if newType == .chatGPT {
+            // Endpoint and key are owned by the OAuth flow — clear them so the
+            // form state can't poison the eventual save.
+            apiBase         = ""
+            apiKey          = ""
+            model           = ""
+            availableModels = []
+            fetchResult     = .none
+            testResult      = .none
+            urlError        = nil
+            chatGPTStatus   = .signedOut
+            signInError     = nil
+            Task { await refreshChatGPTStatus() }
+            return
+        }
         apiBase         = newType.defaultBaseURL
         model           = ""          // user must fetch or type — avoids presetting a model the endpoint may not support
         availableModels = []
@@ -244,6 +364,9 @@ struct ProviderEditSheet: View {
     }
 
     private func validateURL(_ value: String) {
+        // ChatGPT doesn't expose an API base URL field — its endpoint is fixed.
+        if type == .chatGPT { urlError = nil; return }
+
         if value.isEmpty, type == .openAICompatible {
             urlError = "Base URL is required for custom providers"
             return
@@ -328,6 +451,169 @@ struct ProviderEditSheet: View {
         }
     }
 
+    // MARK: - ChatGPT OAuth UI block
+
+    @ViewBuilder
+    private var chatGPTAuthBlock: some View {
+        switch chatGPTStatus {
+        case .signedIn(let email, let plan):
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark.seal.fill").foregroundStyle(.green)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Signed in as \(email ?? "(unknown)")")
+                        .font(.system(size: 12, weight: .medium))
+                    if let plan {
+                        Text("Plan: \(plan)")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+                Button("Sign out", role: .destructive) { signOutChatGPT() }
+                    .controlSize(.small)
+            }
+        case .signedOut:
+            VStack(alignment: .leading, spacing: 8) {
+                Button(action: signInChatGPT) {
+                    HStack(spacing: 6) {
+                        if isSigningIn { ProgressView().controlSize(.small) }
+                        Image(systemName: "person.crop.circle.badge.checkmark")
+                        Text(isSigningIn ? "Waiting for browser…" : "Sign in with OpenAI")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isSigningIn)
+
+                if let signInError {
+                    Text(signInError)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.red)
+                }
+
+                Text("Uses OpenAI's Codex CLI public OAuth client. Not officially supported by OpenAI. Requires a paid ChatGPT plan; may break if OpenAI changes the API. Credentials never leave this device.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func signInChatGPT() {
+        let pid = resolvedId
+        let shouldRollbackOnCancel = editing?.type != .chatGPT
+        isSigningIn = true
+        signInError = nil
+        if shouldRollbackOnCancel {
+            dirtyChatGPTSignIn = true
+        }
+
+        chatGPTSignInTask?.cancel()
+        chatGPTSignInTask = Task {
+            let svc = DependencyContainer.shared.chatGPTOAuthService
+            do {
+                _ = try await svc.signIn(providerId: pid)
+                // The bundle is unconfirmed until Save unless this is a
+                // re-sign-in for a row that was already ChatGPT when opened.
+                await MainActor.run { if shouldRollbackOnCancel { dirtyChatGPTSignIn = true } }
+                // refreshChatGPTStatus() itself fans out to loadChatGPTModels()
+                // when availableModels is empty (true post-sign-in), so calling
+                // it twice would double-hit /models.
+                await refreshChatGPTStatus()
+                await MainActor.run {
+                    isSigningIn = false
+                    chatGPTSignInTask = nil
+                }
+            } catch {
+                await MainActor.run {
+                    if shouldRollbackOnCancel {
+                        dirtyChatGPTSignIn = false
+                    }
+                    signInError = error.localizedDescription
+                    isSigningIn = false
+                    chatGPTSignInTask = nil
+                }
+            }
+        }
+    }
+
+    private func signOutChatGPT() {
+        let pid = resolvedId
+        Task {
+            let svc = DependencyContainer.shared.chatGPTOAuthService
+            try? await svc.signOut(providerId: pid)
+            await refreshChatGPTStatus()
+            await MainActor.run {
+                chatGPTSignInTask?.cancel()
+                chatGPTSignInTask = nil
+                availableModels = []
+                model = ""
+                fetchResult = .none
+                // Bundle is gone; nothing for onDisappear to clean up.
+                dirtyChatGPTSignIn = false
+            }
+        }
+    }
+
+    private func refreshChatGPTStatus() async {
+        let pid = resolvedId
+        let status = await DependencyContainer.shared.chatGPTOAuthService.currentStatus(providerId: pid)
+        // Hop to the main actor only to update view state; decide on the
+        // follow-up model load there too (it reads availableModels), then
+        // await it in the caller's task instead of detaching a new Task.
+        // Detached tasks here would outlive the sheet on dismiss.
+        let needsModelLoad: Bool = await MainActor.run {
+            chatGPTStatus = status
+            if case .signedIn = status, availableModels.isEmpty {
+                return true
+            }
+            return false
+        }
+        if needsModelLoad {
+            await loadChatGPTModels()
+        }
+    }
+
+    /// Populate `availableModels` from the ChatGPT backend after sign-in.
+    /// Falls back to `type.fallbackModelIDs` when the network call fails.
+    private func loadChatGPTModels() async {
+        await MainActor.run { isLoadingModels = true }
+        let pid = resolvedId
+        let svc = DependencyContainer.shared.chatGPTOAuthService
+        // Bypass ProviderRegistry on purpose: in add-mode the SwiftData row
+        // doesn't exist yet (Save hasn't run), so the registry can't resolve
+        // by name. The OAuth service is the only stateful dep — sheet-local
+        // construction is safe and disposable. After Save, ProviderRegistry
+        // would build an equivalent stateless ChatGPTProvider with the same
+        // providerId + oauthService actor and default resolvedBaseURL.
+        let provider = ChatGPTProvider(providerId: pid, oauthService: svc)
+        do {
+            let models = try await provider.availableModels()
+            await MainActor.run {
+                isLoadingModels = false
+                if models.isEmpty {
+                    applyBuiltInFallback(reason: "endpoint returned no models")
+                } else {
+                    availableModels = models
+                    fetchResult = .loaded(models.count)
+                    Self.log.debug("Loaded \(models.count) OpenAI sign-in model(s); selected=\(model, privacy: .public)")
+                }
+            }
+        } catch GridexError.aiAPIKeyMissing {
+            await MainActor.run {
+                isLoadingModels = false
+                chatGPTStatus = .signedOut
+                availableModels = []
+                fetchResult = .none
+                signInError = "Sign-in expired. Please sign in again."
+            }
+        } catch {
+            await MainActor.run {
+                isLoadingModels = false
+                applyBuiltInFallback(reason: error.localizedDescription)
+            }
+        }
+    }
+
     /// Populate the picker with the provider type's built-in model IDs when the
     /// live API can't give us a list. Non-fatal — user can still type any model.
     private func applyBuiltInFallback(reason: String) {
@@ -349,11 +635,13 @@ struct ProviderEditSheet: View {
     private func save() {
         let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedBase = apiBase.trimmingCharacters(in: .whitespacesAndNewlines)
+        // ChatGPT: ignore apiBase/apiKey form fields entirely. The endpoint is
+        // baked into the type, the credentials live under ai.chatgpt.tokens.<id>.
         let config = ProviderConfig(
-            id: editing?.id ?? UUID(),
+            id: resolvedId,
             name: name.trimmingCharacters(in: .whitespacesAndNewlines),
             type: type,
-            apiBase: trimmedBase.isEmpty ? nil : trimmedBase,
+            apiBase: type == .chatGPT ? nil : (trimmedBase.isEmpty ? nil : trimmedBase),
             model: model.trimmingCharacters(in: .whitespacesAndNewlines),
             enabled: enabled,
             createdAt: editing?.createdAt ?? Date()
@@ -366,17 +654,36 @@ struct ProviderEditSheet: View {
                 } else {
                     try await repository.save(config)
                 }
-                // Persist API key (or clear it)
-                let keychainKey = Self.keychainKey(id: config.id)
-                if trimmedKey.isEmpty {
-                    try? keychain.delete(key: keychainKey)
+
+                if config.type == .chatGPT {
+                    // Tokens are already in Keychain from the Sign-in flow.
+                    // Drop any stale API key under the same id — user may
+                    // have switched type from API-key to ChatGPT mid-edit.
+                    try? keychain.delete(key: Self.keychainKey(id: config.id))
+                    await DependencyContainer.shared.providerRegistry.register(
+                        config,
+                        apiKey: "",
+                        chatGPTOAuthService: DependencyContainer.shared.chatGPTOAuthService
+                    )
                 } else {
-                    try keychain.save(key: keychainKey, value: trimmedKey)
+                    // Reverse cleanup: discard any orphan ChatGPT token bundle
+                    // left behind if the user signed in then switched type.
+                    try? keychain.deleteChatGPTTokens(providerId: config.id)
+                    // Persist API key (or clear it)
+                    let keychainKey = Self.keychainKey(id: config.id)
+                    if trimmedKey.isEmpty {
+                        try? keychain.delete(key: keychainKey)
+                    } else {
+                        try keychain.save(key: keychainKey, value: trimmedKey)
+                    }
+                    // Update registry
+                    await DependencyContainer.shared.providerRegistry.register(config, apiKey: trimmedKey)
                 }
-                // Update registry
-                await DependencyContainer.shared.providerRegistry.register(config, apiKey: trimmedKey)
 
                 await MainActor.run {
+                    // SwiftData row now owns the id — clear the rollback arm
+                    // before dismiss(), or onDisappear will sign us back out.
+                    dirtyChatGPTSignIn = false
                     onSaved(config)
                     dismiss()
                 }

--- a/macos/Presentation/Windows/Settings/ProviderEditSheet.swift
+++ b/macos/Presentation/Windows/Settings/ProviderEditSheet.swift
@@ -353,6 +353,16 @@ struct ProviderEditSheet: View {
             Task { await refreshChatGPTStatus() }
             return
         }
+        // Switching OUT of .chatGPT mid-flow: cancel any in-flight OAuth task so
+        // a tardy callback doesn't write tokens to the keychain after the form
+        // has already moved on, and reset the ChatGPT-side UI state so a later
+        // switch back to .chatGPT starts clean.
+        chatGPTSignInTask?.cancel()
+        chatGPTSignInTask = nil
+        isSigningIn       = false
+        signInError       = nil
+        chatGPTStatus     = .signedOut
+
         apiBase         = newType.defaultBaseURL
         model           = ""          // user must fetch or type — avoids presetting a model the endpoint may not support
         availableModels = []

--- a/macos/Presentation/Windows/Settings/SettingsView.swift
+++ b/macos/Presentation/Windows/Settings/SettingsView.swift
@@ -268,7 +268,15 @@ struct AISettingsView: View {
             try? await repository.update(updated)
             let apiKey = (try? keychain.load(key: ProviderEditSheet.keychainKey(id: p.id))) ?? ""
             if enabled {
-                await DependencyContainer.shared.providerRegistry.register(updated, apiKey: apiKey)
+                // Pass the OAuth service unconditionally — non-ChatGPT factory
+                // branches ignore it, ChatGPT requires it (otherwise the
+                // factory hits preconditionFailure when re-enabling a
+                // ChatGPT provider).
+                await DependencyContainer.shared.providerRegistry.register(
+                    updated,
+                    apiKey: apiKey,
+                    chatGPTOAuthService: DependencyContainer.shared.chatGPTOAuthService
+                )
             } else {
                 await DependencyContainer.shared.providerRegistry.unregister(updated.name)
             }
@@ -279,7 +287,11 @@ struct AISettingsView: View {
     private func delete(_ p: ProviderConfig) {
         Task {
             try? await repository.delete(p.id)
+            // Clean up both credential variants — only one is set in practice,
+            // but deleting both is cheap and avoids leaks if the type was ever
+            // changed from API-key to ChatGPT (or vice versa) for the same id.
             try? keychain.delete(key: ProviderEditSheet.keychainKey(id: p.id))
+            try? keychain.deleteChatGPTTokens(providerId: p.id)
             await DependencyContainer.shared.providerRegistry.unregister(p.name)
             await MainActor.run { reload() }
         }

--- a/macos/Services/AI/Auth/ChatGPTOAuthConstants.swift
+++ b/macos/Services/AI/Auth/ChatGPTOAuthConstants.swift
@@ -1,0 +1,53 @@
+// ChatGPTOAuthConstants.swift
+// Gridex
+//
+// Endpoint + parameter constants for the ChatGPT OAuth flow. All values mirror
+// OpenAI's Codex CLI v2.x behaviour (see codex-rs/login/src/server.rs in the
+// openai/codex repo). Reusing the public Codex client_id is a deliberate
+// trade-off — see plan F.2 disclaimer.
+
+import Foundation
+
+enum ChatGPTOAuthConstants {
+    /// The public OAuth client_id baked into OpenAI's Codex CLI. Reused here
+    /// because the authorize endpoint only accepts loopback redirect URIs that
+    /// were registered for this client. OpenAI may revoke it at any time.
+    static let clientId = "app_EMoamEEZ73f0CkXaXp7hrann"
+
+    /// Base of the OAuth issuer. `/oauth/authorize` and `/oauth/token` hang off this.
+    static let issuer = URL(string: "https://auth.openai.com")!
+
+    /// Scope set required by the Codex CLI flow. `offline_access` is what gives
+    /// us a refresh_token; the `api.connectors.*` scopes are what lets the
+    /// access_token reach `chatgpt.com/backend-api/codex`.
+    static let scopes = "openid profile email offline_access api.connectors.read api.connectors.invoke"
+
+    /// Backend used by signed-in callers. Distinct from `api.openai.com/v1`.
+    /// Derived from ProviderType so Core remains the single source of truth.
+    static let backend = URL(string: ProviderType.chatGPT.defaultBaseURL)!
+
+    /// Identifier sent as the `originator` query param. Codex CLI uses
+    /// `codex_cli_rs`; we identify ourselves so a future audit can tell.
+    /// Deviates from the original plan ("gridex_cli") on purpose — this client
+    /// is a macOS GUI, not a CLI, and the value is informational only (the
+    /// auth server doesn't gate behaviour on it).
+    static let originator = "gridex_macos"
+
+    /// 3 minutes — long enough for password manager + 2FA, short enough to
+    /// guarantee `signIn` does not hang the UI indefinitely.
+    static let callbackTimeout: TimeInterval = 180
+
+    /// Refresh tokens slightly before the JWT actually expires, so a request
+    /// in flight at `exp` doesn't hit a 401.
+    static let refreshSkew: TimeInterval = 30
+
+    /// Loopback ports tried in order. The OAuth client_id is registered for
+    /// `http://localhost:<any-port>/auth/callback`; Codex CLI defaults to 1455.
+    /// We follow the same order so that a stuck listener from a prior `codex`
+    /// invocation in the same shell doesn't immediately collide.
+    static let preferredPorts: [UInt16] = [1455, 1456, 1457, 1458]
+
+    /// Path component of the redirect URI. Used by both the listener and the
+    /// authorize-URL builder to stay in sync.
+    static let callbackPath = "/auth/callback"
+}

--- a/macos/Services/AI/Auth/ChatGPTOAuthLoopbackServer.swift
+++ b/macos/Services/AI/Auth/ChatGPTOAuthLoopbackServer.swift
@@ -1,0 +1,364 @@
+// ChatGPTOAuthLoopbackServer.swift
+// Gridex
+//
+// Single-shot loopback HTTP listener used by the ChatGPT OAuth flow.
+// The browser receives a `redirect_uri=http://localhost:<port>/auth/callback`
+// query param; once it follows the redirect with `code` + `state` we parse
+// them out, send a tiny "you can close this window" page back, and tear down.
+//
+// Trust verified by reverse-engineering Codex CLI: the OAuth client_id accepts
+// any loopback port for this redirect path. Binding to 127.0.0.1 (not 0.0.0.0)
+// prevents LAN-side hijack.
+
+import Foundation
+import Network
+import os
+
+/// Result extracted from the browser's GET to `/auth/callback`.
+struct ChatGPTOAuthCallback: Sendable {
+    let code: String
+    let state: String
+}
+
+enum ChatGPTOAuthLoopbackError: Error, LocalizedError, CustomStringConvertible {
+    case noPortAvailable(tried: [UInt16])
+    case timedOut(after: TimeInterval)
+    case malformedRequest(reason: String)
+    case authError(code: String, description: String?)
+    /// `NWListener` reported `.cancelled` before reaching `.ready`. Distinct
+    /// from `malformedRequest` because no browser request is involved.
+    case listenerCancelled
+
+    var description: String {
+        switch self {
+        case .noPortAvailable(let tried):
+            return "Could not bind any of the loopback ports: \(tried)"
+        case .timedOut(let s):
+            return "OAuth callback did not arrive within \(Int(s))s"
+        case .malformedRequest(let why):
+            return "Browser callback was malformed: \(why)"
+        case .authError(let code, let desc):
+            return "Authorization server returned error '\(code)': \(desc ?? "(no description)")"
+        case .listenerCancelled:
+            return "OAuth loopback listener was cancelled before becoming ready"
+        }
+    }
+
+    /// Foundation reads this for `error.localizedDescription`. Without this
+    /// override callers see the default `Error._domain`-prefixed string and
+    /// lose the `description` payload we built above.
+    var errorDescription: String? { description }
+}
+
+/// One-shot loopback HTTP server. Create it, call `start()`, then `awaitCallback()`,
+/// then it self-tears-down. Re-using an instance after success is not supported.
+///
+/// The class is `@unchecked Sendable` because `NWListener` callbacks fire on
+/// internal queues — we serialize state mutation through a lock.
+final class ChatGPTOAuthLoopbackServer: @unchecked Sendable {
+
+    private static let log = Logger(subsystem: "com.gridex.gridex", category: "ChatGPTOAuth")
+
+    private let lock = NSLock()
+    private var listener: NWListener?
+    private var connections: [NWConnection] = []
+    private var continuation: CheckedContinuation<ChatGPTOAuthCallback, Error>?
+    private var resolvedResult: Result<ChatGPTOAuthCallback, Error>?
+    private var resolved = false
+    /// The 180-second timeout sleeper. Tracked so a successful callback can
+    /// cancel it instead of leaving a stranded Task that wakes up minutes
+    /// later only to find `resolved == true` and exit.
+    private var timeoutTask: Task<Void, Never>?
+
+    private(set) var actualPort: UInt16 = 0
+
+    /// Best-effort response body sent to the browser after a successful callback.
+    /// Plain HTML (Safari frequently ignores `window.close()` from non-script-opened
+    /// tabs, but the JS attempt is harmless on Chrome/Firefox).
+    private static let successPage =
+"""
+<!doctype html><html><head><meta charset="utf-8"><title>Gridex sign-in</title>
+<style>body{font:14px -apple-system;color:#333;text-align:center;padding:80px}</style>
+</head><body><h2>Sign-in complete</h2>
+<p>You can close this tab and return to Gridex.</p>
+<script>setTimeout(()=>window.close(),500)</script>
+</body></html>
+"""
+
+    private static let errorPage =
+"""
+<!doctype html><html><head><meta charset="utf-8"><title>Gridex sign-in</title>
+<style>body{font:14px -apple-system;color:#333;text-align:center;padding:80px}</style>
+</head><body><h2>Sign-in failed</h2>
+<p>Return to Gridex for details. You can close this tab.</p>
+</body></html>
+"""
+
+    /// Starts the listener on the first available port from `preferredPorts`,
+    /// then falls back to a kernel-assigned ephemeral port. Returns the port
+    /// that was bound.
+    func start(preferredPorts: [UInt16] = ChatGPTOAuthConstants.preferredPorts) async throws -> UInt16 {
+        // Build a candidate list: preferred first, then `0` (ephemeral) as last resort.
+        let candidates = preferredPorts + [0]
+        var triedPorts: [UInt16] = []
+
+        for candidate in candidates {
+            triedPorts.append(candidate)
+            do {
+                let port: UInt16 = try await tryBind(port: candidate)
+                actualPort = port
+                Self.log.info("OAuth loopback listening on 127.0.0.1:\(port)")
+                return port
+            } catch {
+                Self.log.notice("OAuth loopback port \(candidate) unavailable: \(error.localizedDescription, privacy: .public)")
+                continue
+            }
+        }
+        throw ChatGPTOAuthLoopbackError.noPortAvailable(tried: triedPorts)
+    }
+
+    /// Awaits a single callback or fails with `.timedOut`. Calling this without
+    /// a preceding `start()` returns immediately with a programming error.
+    func awaitCallback(timeout: TimeInterval) async throws -> ChatGPTOAuthCallback {
+        precondition(actualPort != 0 || listener != nil, "must call start() before awaitCallback()")
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<ChatGPTOAuthCallback, Error>) in
+                lock.lock()
+                if resolved {
+                    let result = self.resolvedResult
+                    lock.unlock()
+                    switch result {
+                    case .success(let callback):
+                        cont.resume(returning: callback)
+                    case .failure(let error):
+                        cont.resume(throwing: error)
+                    case .none:
+                        cont.resume(throwing: ChatGPTOAuthLoopbackError.malformedRequest(reason: "already resolved"))
+                    }
+                    return
+                }
+                self.continuation = cont
+                let task = Task { [weak self] in
+                    try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                    guard let self else { return }
+                    if Task.isCancelled { return }
+                    self.resolveFailure(ChatGPTOAuthLoopbackError.timedOut(after: timeout))
+                }
+                self.timeoutTask = task
+                lock.unlock()
+            }
+        } onCancel: {
+            self.resolveFailure(CancellationError())
+        }
+    }
+
+    /// Tear down all sockets. Idempotent.
+    func stop() {
+        lock.lock()
+        defer { lock.unlock() }
+        listener?.cancel()
+        listener = nil
+        for c in connections { c.cancel() }
+        connections.removeAll()
+    }
+
+    // MARK: - Internal
+
+    private func tryBind(port: UInt16) async throws -> UInt16 {
+        let nwPort: NWEndpoint.Port = (port == 0) ? .any : NWEndpoint.Port(rawValue: port)!
+        let params = NWParameters.tcp
+        params.requiredLocalEndpoint = NWEndpoint.hostPort(host: .ipv4(.loopback), port: nwPort)
+
+        let listener = try NWListener(using: params)
+        self.listener = listener
+
+        listener.newConnectionHandler = { [weak self] conn in
+            self?.handleConnection(conn)
+        }
+
+        // Bridge `state` → async via continuation. Resume only on .ready/.failed/.cancelled.
+        let actualPort: UInt16 = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<UInt16, Error>) in
+            var resumed = false
+            listener.stateUpdateHandler = { state in
+                guard !resumed else { return }
+                switch state {
+                case .ready:
+                    resumed = true
+                    let p = listener.port?.rawValue ?? port
+                    cont.resume(returning: p)
+                case .failed(let err):
+                    resumed = true
+                    cont.resume(throwing: err)
+                case .cancelled:
+                    resumed = true
+                    cont.resume(throwing: ChatGPTOAuthLoopbackError.listenerCancelled)
+                default:
+                    break
+                }
+            }
+            listener.start(queue: .global(qos: .userInitiated))
+        }
+        return actualPort
+    }
+
+    private func handleConnection(_ conn: NWConnection) {
+        lock.lock()
+        connections.append(conn)
+        lock.unlock()
+
+        conn.start(queue: .global(qos: .userInitiated))
+        receiveRequest(conn, accumulated: Data())
+    }
+
+    /// Accumulates bytes until `\r\n\r\n` end-of-headers, then parses the GET line.
+    /// We don't need to read the body — the OAuth callback is GET-only.
+    private func receiveRequest(_ conn: NWConnection, accumulated: Data) {
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 8192) { [weak self] chunk, _, isComplete, error in
+            guard let self else { return }
+
+            var buffer = accumulated
+            if let chunk { buffer.append(chunk) }
+
+            if let error = error {
+                Self.log.error("OAuth loopback receive error: \(error.localizedDescription, privacy: .public)")
+                conn.cancel()
+                self.resolveFailure(error)
+                return
+            }
+
+            // Look for end-of-headers (CRLF CRLF or LF LF as a fallback).
+            if let range = buffer.range(of: Data("\r\n\r\n".utf8)) ?? buffer.range(of: Data("\n\n".utf8)) {
+                let head = buffer[..<range.lowerBound]
+                self.processHead(head, on: conn)
+                return
+            }
+
+            if isComplete {
+                conn.cancel()
+                self.resolveFailure(ChatGPTOAuthLoopbackError.malformedRequest(reason: "connection closed before headers ended"))
+                return
+            }
+
+            if buffer.count > 64 * 1024 {
+                // Defensive cap — a real OAuth callback URL is well under 4 KB.
+                conn.cancel()
+                self.resolveFailure(ChatGPTOAuthLoopbackError.malformedRequest(reason: "headers exceed 64KB"))
+                return
+            }
+
+            self.receiveRequest(conn, accumulated: buffer)
+        }
+    }
+
+    private func processHead(_ head: Data, on conn: NWConnection) {
+        guard let text = String(data: head, encoding: .utf8) else {
+            sendErrorPage(conn)
+            resolveFailure(ChatGPTOAuthLoopbackError.malformedRequest(reason: "request bytes are not UTF-8"))
+            return
+        }
+
+        let firstLine = text.split(whereSeparator: { $0 == "\r" || $0 == "\n" }).first ?? ""
+        let parts = firstLine.split(separator: " ", maxSplits: 2)
+        guard parts.count >= 2 else {
+            sendErrorPage(conn)
+            resolveFailure(ChatGPTOAuthLoopbackError.malformedRequest(reason: "request line malformed: \(firstLine)"))
+            return
+        }
+        // parts[0] = "GET", parts[1] = "/auth/callback?code=...&state=..."
+        let pathAndQuery = String(parts[1])
+
+        // Use URLComponents to parse query items robustly.
+        // We prepend a fake host because URLComponents doesn't like bare paths.
+        guard let comps = URLComponents(string: "http://localhost\(pathAndQuery)") else {
+            sendErrorPage(conn)
+            resolveFailure(ChatGPTOAuthLoopbackError.malformedRequest(reason: "could not parse path: \(pathAndQuery)"))
+            return
+        }
+
+        if comps.path != ChatGPTOAuthConstants.callbackPath {
+            // Probably a /favicon.ico or stray probe — keep listening for the real one.
+            sendErrorPage(conn)
+            return
+        }
+
+        let items = comps.queryItems ?? []
+        let code        = items.first(where: { $0.name == "code" })?.value
+        let state       = items.first(where: { $0.name == "state" })?.value
+        let errCode     = items.first(where: { $0.name == "error" })?.value
+        let errDesc     = items.first(where: { $0.name == "error_description" })?.value
+
+        if let errCode = errCode {
+            sendErrorPage(conn)
+            resolveFailure(ChatGPTOAuthLoopbackError.authError(code: errCode, description: errDesc))
+            return
+        }
+
+        guard let code = code, let state = state else {
+            sendErrorPage(conn)
+            resolveFailure(ChatGPTOAuthLoopbackError.malformedRequest(reason: "missing code or state in callback"))
+            return
+        }
+
+        sendSuccessPage(conn)
+        resolveSuccess(ChatGPTOAuthCallback(code: code, state: state))
+    }
+
+    private func sendSuccessPage(_ conn: NWConnection) {
+        sendHTML(conn, status: 200, body: Self.successPage)
+    }
+
+    private func sendErrorPage(_ conn: NWConnection) {
+        sendHTML(conn, status: 400, body: Self.errorPage)
+    }
+
+    private func sendHTML(_ conn: NWConnection, status: Int, body: String) {
+        let bytes = body.data(using: .utf8) ?? Data()
+        let head = """
+HTTP/1.1 \(status) OK\r
+Content-Type: text/html; charset=utf-8\r
+Content-Length: \(bytes.count)\r
+Connection: close\r
+\r
+
+"""
+        var packet = Data(head.utf8)
+        packet.append(bytes)
+        conn.send(content: packet, completion: .contentProcessed { _ in
+            conn.cancel()
+        })
+    }
+
+    private func resolveSuccess(_ callback: ChatGPTOAuthCallback) {
+        lock.lock()
+        guard !resolved else { lock.unlock(); return }
+        resolved = true
+        self.resolvedResult = .success(callback)
+        let cont = self.continuation
+        let timer = self.timeoutTask
+        self.continuation = nil
+        self.timeoutTask = nil
+        lock.unlock()
+
+        timer?.cancel()
+        cont?.resume(returning: callback)
+        // Tear down all sockets — listener fires last.
+        stop()
+    }
+
+    private func resolveFailure(_ error: Error) {
+        lock.lock()
+        guard !resolved else { lock.unlock(); return }
+        resolved = true
+        self.resolvedResult = .failure(error)
+        let cont = self.continuation
+        let timer = self.timeoutTask
+        self.continuation = nil
+        self.timeoutTask = nil
+        lock.unlock()
+
+        timer?.cancel()
+        cont?.resume(throwing: error)
+        stop()
+    }
+}

--- a/macos/Services/AI/Auth/ChatGPTOAuthService.swift
+++ b/macos/Services/AI/Auth/ChatGPTOAuthService.swift
@@ -1,0 +1,298 @@
+// ChatGPTOAuthService.swift
+// Gridex
+//
+// Owns the full ChatGPT OAuth lifecycle:
+//   - signIn(providerId:)         — interactive PKCE flow, opens the browser
+//   - tokenBundle(providerId:)    — non-interactive, refreshes if access token
+//                                    is within `refreshSkew` of expiring
+//   - signOut(providerId:)        — clears the Keychain blob
+//   - currentStatus(providerId:)  — UI helper, no network
+//
+// Concurrency model: actor. In-flight refreshes are coalesced per providerId so
+// that a burst of `tokenBundle()` calls only triggers one network round-trip.
+
+import AppKit
+import Foundation
+import os
+
+actor ChatGPTOAuthService {
+
+    private static let log = Logger(subsystem: "com.gridex.gridex", category: "ChatGPTOAuth")
+
+    private let keychain: KeychainServiceProtocol
+    private let urlSession: URLSession
+    private var refreshInFlight: [UUID: Task<ChatGPTTokenBundle, Error>] = [:]
+
+    init(keychainService: KeychainServiceProtocol, urlSession: URLSession = .shared) {
+        self.keychain = keychainService
+        self.urlSession = urlSession
+    }
+
+    enum SignInStatus: Equatable, Sendable {
+        case signedOut
+        case signedIn(email: String?, plan: String?)
+    }
+
+    // MARK: - Public API
+
+    /// Runs the full PKCE flow: opens browser, waits for /auth/callback,
+    /// exchanges the code for tokens, persists them, returns the bundle.
+    /// Call from any context — interaction with NSWorkspace happens on MainActor
+    /// internally.
+    @discardableResult
+    func signIn(providerId: UUID) async throws -> ChatGPTTokenBundle {
+        Self.log.info("ChatGPT OAuth sign-in starting for provider \(providerId.uuidString, privacy: .public)")
+
+        let verifier  = PKCE.makeVerifier()
+        let challenge = PKCE.challenge(for: verifier)
+        let state     = PKCE.makeState()
+
+        let server = ChatGPTOAuthLoopbackServer()
+        let port = try await server.start()
+        let redirectURI = "http://localhost:\(port)\(ChatGPTOAuthConstants.callbackPath)"
+
+        // Open the browser. NSWorkspace must be touched on the main thread.
+        let authURL = buildAuthorizeURL(challenge: challenge, state: state, redirectURI: redirectURI)
+        Self.log.debug("Opening browser to authorize URL")
+        let didOpenBrowser = await MainActor.run {
+            NSWorkspace.shared.open(authURL)
+        }
+        guard didOpenBrowser else {
+            server.stop()
+            Self.log.error("ChatGPT OAuth sign-in failed: LaunchServices could not open browser")
+            throw GridexError.aiProviderError("Could not open browser for ChatGPT sign-in")
+        }
+
+        // Block on the browser callback (or 3-min timeout).
+        let callback: ChatGPTOAuthCallback
+        do {
+            callback = try await server.awaitCallback(timeout: ChatGPTOAuthConstants.callbackTimeout)
+        } catch {
+            server.stop()
+            Self.log.error("OAuth callback failed: \(error.localizedDescription, privacy: .public)")
+            throw GridexError.aiProviderError("Sign-in failed: \(error.localizedDescription)")
+        }
+
+        // CSRF check — the auth server echoes our `state` back to the redirect URI.
+        guard callback.state == state else {
+            Self.log.error("OAuth state mismatch — possible CSRF")
+            throw GridexError.aiProviderError("State mismatch — sign-in aborted (possible CSRF)")
+        }
+
+        // Exchange the authorization code for tokens.
+        let tokens = try await exchangeCodeForTokens(
+            code: callback.code,
+            verifier: verifier,
+            redirectURI: redirectURI
+        )
+
+        let bundle = try buildBundle(from: tokens)
+        try keychain.saveChatGPTTokens(providerId: providerId, bundle: bundle)
+        Self.log.info("ChatGPT OAuth sign-in complete; email=\(bundle.email ?? "?", privacy: .private)")
+
+        // Bring Gridex back to the front — Safari may not auto-close the tab.
+        await MainActor.run {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+
+        return bundle
+    }
+
+    /// Returns a usable token bundle, refreshing via `refresh_token` if the
+    /// stored `access_token` is within `refreshSkew` of expiring.
+    /// Coalesces concurrent calls per `providerId`.
+    func tokenBundle(providerId: UUID) async throws -> ChatGPTTokenBundle {
+        guard let bundle = try keychain.loadChatGPTTokens(providerId: providerId) else {
+            throw GridexError.aiAPIKeyMissing
+        }
+
+        let exp = JWTDecoder.expiration(of: bundle.accessToken) ?? .distantPast
+        if Date() < exp.addingTimeInterval(-ChatGPTOAuthConstants.refreshSkew) {
+            return bundle
+        }
+
+        if let inflight = refreshInFlight[providerId] {
+            return try await inflight.value
+        }
+
+        let task = Task<ChatGPTTokenBundle, Error> { [self] in
+            try await self.performRefresh(bundle: bundle, providerId: providerId)
+        }
+        refreshInFlight[providerId] = task
+        defer { refreshInFlight[providerId] = nil }
+        return try await task.value
+    }
+
+    /// Deletes the persisted bundle. Cheap; does not call the auth server.
+    func signOut(providerId: UUID) throws {
+        Self.log.info("ChatGPT sign-out for \(providerId.uuidString, privacy: .public)")
+        try keychain.deleteChatGPTTokens(providerId: providerId)
+    }
+
+    /// Non-network status used by the settings sheet to render "Signed in as ..."
+    /// chrome.
+    func currentStatus(providerId: UUID) -> SignInStatus {
+        guard let bundle = try? keychain.loadChatGPTTokens(providerId: providerId) else {
+            return .signedOut
+        }
+        return .signedIn(email: bundle.email, plan: bundle.planType)
+    }
+
+    // MARK: - Internal
+
+    private struct TokenResponse: Decodable {
+        let access_token: String
+        let refresh_token: String?
+        let id_token: String?
+    }
+
+    private func buildAuthorizeURL(challenge: String, state: String, redirectURI: String) -> URL {
+        var comps = URLComponents(url: ChatGPTOAuthConstants.issuer.appendingPathComponent("oauth/authorize"),
+                                  resolvingAgainstBaseURL: false)!
+        comps.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: ChatGPTOAuthConstants.clientId),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "scope", value: ChatGPTOAuthConstants.scopes),
+            URLQueryItem(name: "code_challenge", value: challenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "id_token_add_organizations", value: "true"),
+            URLQueryItem(name: "codex_cli_simplified_flow", value: "true"),
+            URLQueryItem(name: "originator", value: ChatGPTOAuthConstants.originator),
+        ]
+        return comps.url!
+    }
+
+    private func exchangeCodeForTokens(code: String, verifier: String, redirectURI: String) async throws -> TokenResponse {
+        let url = ChatGPTOAuthConstants.issuer.appendingPathComponent("oauth/token")
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        // form-encode body
+        let body = [
+            "grant_type":    "authorization_code",
+            "code":          code,
+            "redirect_uri":  redirectURI,
+            "client_id":     ChatGPTOAuthConstants.clientId,
+            "code_verifier": verifier,
+        ]
+            .map { "\($0.key)=\(encode($0.value))" }
+            .joined(separator: "&")
+        req.httpBody = Data(body.utf8)
+
+        let (data, response) = try await urlSession.data(for: req)
+        guard let http = response as? HTTPURLResponse else {
+            throw GridexError.aiProviderError("Token exchange: non-HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let detail = parseErrorBody(data)
+            Self.log.error("Token exchange failed: HTTP \(http.statusCode) \(detail, privacy: .public)")
+            throw GridexError.aiProviderError("Token exchange failed (HTTP \(http.statusCode)): \(detail)")
+        }
+
+        do {
+            return try JSONDecoder().decode(TokenResponse.self, from: data)
+        } catch {
+            Self.log.error("Token exchange: malformed body — \(error.localizedDescription, privacy: .public)")
+            throw GridexError.aiProviderError("Token exchange returned an unexpected payload")
+        }
+    }
+
+    /// JSON-bodied refresh per Codex CLI behaviour. The auth server returns the
+    /// new access_token (and may rotate refresh_token + id_token). When fields
+    /// are absent we keep the old values.
+    private func performRefresh(bundle: ChatGPTTokenBundle, providerId: UUID) async throws -> ChatGPTTokenBundle {
+        Self.log.info("ChatGPT token refresh for \(providerId.uuidString, privacy: .public)")
+        let url = ChatGPTOAuthConstants.issuer.appendingPathComponent("oauth/token")
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: String] = [
+            "client_id":     ChatGPTOAuthConstants.clientId,
+            "grant_type":    "refresh_token",
+            "refresh_token": bundle.refreshToken,
+        ]
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await urlSession.data(for: req)
+        guard let http = response as? HTTPURLResponse else {
+            throw GridexError.aiProviderError("Refresh: non-HTTP response")
+        }
+
+        if (200..<300).contains(http.statusCode) {
+            let parsed = try JSONDecoder().decode(TokenResponse.self, from: data)
+            // Merge new values over the old bundle. refresh_token / id_token may rotate.
+            var updated = bundle
+            updated.accessToken = parsed.access_token
+            if let rt = parsed.refresh_token, !rt.isEmpty { updated.refreshToken = rt }
+            if let idt = parsed.id_token, !idt.isEmpty {
+                updated.idToken = idt
+                applyClaims(into: &updated)
+            }
+            updated.obtainedAt = Date()
+            try keychain.saveChatGPTTokens(providerId: providerId, bundle: updated)
+            Self.log.info("Refresh ok; new exp=\(JWTDecoder.expiration(of: updated.accessToken)?.timeIntervalSince1970 ?? 0)")
+            return updated
+        }
+
+        // Failure path. If the auth server says the refresh_token is no longer
+        // valid, blow the bundle away and surface aiAPIKeyMissing — the UI will
+        // prompt the user to sign in again.
+        let detail = parseErrorBody(data)
+        let lower = detail.lowercased()
+        let dead = ["refresh_token_expired", "refresh_token_reused", "refresh_token_invalidated"]
+        if dead.contains(where: lower.contains) {
+            Self.log.notice("Refresh token rejected (\(detail, privacy: .public)); clearing keychain")
+            try? keychain.deleteChatGPTTokens(providerId: providerId)
+            throw GridexError.aiAPIKeyMissing
+        }
+        throw GridexError.aiProviderError("Refresh failed (HTTP \(http.statusCode)): \(detail)")
+    }
+
+    /// Decodes the id_token claims into the bundle's UI-friendly fields.
+    private func applyClaims(into bundle: inout ChatGPTTokenBundle) {
+        guard let claims = try? JWTDecoder.payload(of: bundle.idToken) else { return }
+        bundle.email     = claims["email"] as? String ?? bundle.email
+        bundle.accountId = claims["chatgpt_account_id"] as? String ?? bundle.accountId
+        bundle.planType  = claims["chatgpt_plan_type"] as? String ?? bundle.planType
+    }
+
+    /// Build a fresh bundle from a successful token exchange response.
+    private func buildBundle(from tokens: TokenResponse) throws -> ChatGPTTokenBundle {
+        guard let idToken = tokens.id_token, !idToken.isEmpty else {
+            throw GridexError.aiProviderError("Token exchange returned no id_token")
+        }
+        guard let refresh = tokens.refresh_token, !refresh.isEmpty else {
+            throw GridexError.aiProviderError("Token exchange returned no refresh_token (offline_access scope missing?)")
+        }
+        var b = ChatGPTTokenBundle(
+            accessToken: tokens.access_token,
+            refreshToken: refresh,
+            idToken: idToken
+        )
+        applyClaims(into: &b)
+        return b
+    }
+
+    private func encode(_ value: String) -> String {
+        // Application/x-www-form-urlencoded — URL-encode + use `+` for spaces.
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "+&=")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+    }
+
+    private func parseErrorBody(_ data: Data) -> String {
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let err = json["error"] as? String {
+                if let desc = json["error_description"] as? String { return "\(err): \(desc)" }
+                return err
+            }
+            if let msg = json["message"] as? String { return msg }
+        }
+        return String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? "(empty body)"
+    }
+}

--- a/macos/Services/AI/Auth/JWTDecoder.swift
+++ b/macos/Services/AI/Auth/JWTDecoder.swift
@@ -1,0 +1,66 @@
+// JWTDecoder.swift
+// Gridex
+//
+// Minimal JWT payload decoder. We never verify the signature here — the issuer
+// is auth.openai.com over TLS, and refresh failures are surfaced by the server.
+// We only need to read claims (`exp`, `email`, `chatgpt_account_id`, …).
+
+import Foundation
+
+enum JWTDecoder {
+    enum DecodeError: Error, CustomStringConvertible {
+        case malformed(String)
+        var description: String {
+            switch self {
+            case .malformed(let why): return "Malformed JWT: \(why)"
+            }
+        }
+    }
+
+    /// Decodes the second segment of a JWT (the payload) into a JSON dictionary.
+    /// Throws `DecodeError.malformed` if the token doesn't have the expected
+    /// `header.payload.signature` shape or the payload isn't a JSON object.
+    static func payload(of jwt: String) throws -> [String: Any] {
+        let parts = jwt.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3 else {
+            throw DecodeError.malformed("expected 3 segments, got \(parts.count)")
+        }
+        guard let data = base64URLDecode(String(parts[1])) else {
+            throw DecodeError.malformed("payload is not valid base64url")
+        }
+        guard
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw DecodeError.malformed("payload is not a JSON object")
+        }
+        return json
+    }
+
+    /// Convenience: extract the `exp` claim and convert to a Date. Returns nil
+    /// if the claim is missing or not a number — caller should treat that as
+    /// "expired" (forces a refresh).
+    static func expiration(of jwt: String) -> Date? {
+        guard let claims = try? payload(of: jwt) else { return nil }
+        guard let exp = claims["exp"] as? TimeInterval else {
+            // Some JWTs encode exp as Int — try that too
+            if let expInt = claims["exp"] as? Int {
+                return Date(timeIntervalSince1970: TimeInterval(expInt))
+            }
+            return nil
+        }
+        return Date(timeIntervalSince1970: exp)
+    }
+
+    // MARK: - Internal
+
+    /// base64url → Data. Re-pads to a multiple of 4 with `=` and reverses the
+    /// URL-safe substitutions before delegating to `Data(base64Encoded:)`.
+    static func base64URLDecode(_ s: String) -> Data? {
+        var str = s
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let pad = str.count % 4
+        if pad > 0 { str.append(String(repeating: "=", count: 4 - pad)) }
+        return Data(base64Encoded: str)
+    }
+}

--- a/macos/Services/AI/Auth/PKCE.swift
+++ b/macos/Services/AI/Auth/PKCE.swift
@@ -1,0 +1,58 @@
+// PKCE.swift
+// Gridex
+//
+// RFC 7636 PKCE primitives for the ChatGPT OAuth flow. Pure functions, no I/O.
+//
+// All outputs are base64url-no-pad: standard base64, then `+` → `-`, `/` → `_`,
+// trailing `=` stripped.
+
+import CryptoKit
+import Foundation
+import Security
+
+enum PKCE {
+    /// 32 random bytes → base64url-no-pad (43 chars). Suitable as `code_verifier`.
+    static func makeVerifier() -> String {
+        base64URL(randomBytes(count: 32))
+    }
+
+    /// SHA256(verifier) → base64url-no-pad. Used as `code_challenge`
+    /// with `code_challenge_method=S256`.
+    static func challenge(for verifier: String) -> String {
+        let data = Data(verifier.utf8)
+        let hash = SHA256.hash(data: data)
+        return base64URL(Data(hash))
+    }
+
+    /// 32 random bytes → base64url-no-pad. Used as the OAuth `state` param to
+    /// detect CSRF on the loopback callback.
+    static func makeState() -> String {
+        base64URL(randomBytes(count: 32))
+    }
+
+    /// Standard base64 → URL-safe variant (no padding).
+    /// Exposed for tests that need to verify against RFC 7636 vectors.
+    static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    // MARK: - Internal
+
+    /// Cryptographically secure random bytes via Security framework's CSPRNG.
+    /// Falls back to `SystemRandomNumberGenerator` only if `SecRandomCopyBytes`
+    /// somehow fails — should never happen on healthy macOS hosts.
+    private static func randomBytes(count: Int) -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+        guard status == errSecSuccess else {
+            // Last-resort fallback — keeps the API total without crashing.
+            var rng = SystemRandomNumberGenerator()
+            for i in 0..<count { bytes[i] = UInt8.random(in: 0...255, using: &rng) }
+            return Data(bytes)
+        }
+        return Data(bytes)
+    }
+}

--- a/macos/Services/AI/ProviderFactory.swift
+++ b/macos/Services/AI/ProviderFactory.swift
@@ -8,7 +8,20 @@
 import Foundation
 
 enum ProviderFactory {
-    static func make(config: ProviderConfig, apiKey: String) -> any LLMService {
+    /// Build the concrete `LLMService` for a config. `apiKey` is ignored for
+    /// `.chatGPT` (it uses OAuth tokens via `chatGPTOAuthService`); pass empty
+    /// for that case.
+    ///
+    /// `chatGPTOAuthService` must be provided when `config.type == .chatGPT`;
+    /// other types ignore it. We pass it explicitly (rather than reach for
+    /// `DependencyContainer.shared`) because the factory is callable from
+    /// non-MainActor contexts (`ProviderRegistry` is an actor) — and the
+    /// container is `@MainActor`-isolated.
+    static func make(
+        config: ProviderConfig,
+        apiKey: String,
+        chatGPTOAuthService: ChatGPTOAuthService? = nil
+    ) -> any LLMService {
         let base = config.resolvedBaseURL
         switch config.type {
         case .anthropic:
@@ -17,6 +30,11 @@ enum ProviderFactory {
             return GeminiProvider(apiKey: apiKey, baseURL: base)
         case .ollama:
             return OllamaProvider(baseURLString: base)
+        case .chatGPT:
+            guard let svc = chatGPTOAuthService else {
+                preconditionFailure("ChatGPT provider requires chatGPTOAuthService")
+            }
+            return ChatGPTProvider(providerId: config.id, baseURL: base, oauthService: svc)
         case .openAI, .azureOpenAI, .groq, .deepseek, .mistral, .xAI,
              .perplexity, .openRouter, .together, .fireworks, .dashscope,
              .dashscopeCoding, .openAICompatible:
@@ -24,7 +42,8 @@ enum ProviderFactory {
         }
     }
 
-    /// Convenience for legacy callers that only know the type.
+    /// Convenience for legacy callers that only know the type. Cannot build a
+    /// ChatGPT provider — that requires an explicit provider id + OAuth service.
     static func make(type: ProviderType, apiKey: String, baseURL: String? = nil) -> any LLMService {
         let config = ProviderConfig(
             name: type.rawValue,

--- a/macos/Services/AI/ProviderFactory.swift
+++ b/macos/Services/AI/ProviderFactory.swift
@@ -32,7 +32,11 @@ enum ProviderFactory {
             return OllamaProvider(baseURLString: base)
         case .chatGPT:
             guard let svc = chatGPTOAuthService else {
-                preconditionFailure("ChatGPT provider requires chatGPTOAuthService")
+                // Surface as a normal LLMService error rather than crashing —
+                // misconfiguration in a future caller (e.g. the legacy
+                // type-only `make(type:apiKey:baseURL:)`) becomes a clean
+                // GridexError on first use instead of a process crash.
+                return MisconfiguredChatGPTProvider()
             }
             return ChatGPTProvider(providerId: config.id, baseURL: base, oauthService: svc)
         case .openAI, .azureOpenAI, .groq, .deepseek, .mistral, .xAI,
@@ -52,5 +56,39 @@ enum ProviderFactory {
             model: type.defaultModel
         )
         return make(config: config, apiKey: apiKey)
+    }
+}
+
+/// Stand-in returned when `make(...)` is asked for a `.chatGPT` provider but
+/// the caller didn't thread the OAuth service through. Every method throws
+/// `GridexError.aiProviderError`, so the misconfiguration surfaces as a normal
+/// in-band error on the first request rather than a process-wide crash.
+private struct MisconfiguredChatGPTProvider: LLMService {
+    let providerName = "ChatGPT (misconfigured)"
+
+    func stream(
+        messages: [LLMMessage],
+        systemPrompt: String,
+        model: String,
+        maxTokens: Int,
+        temperature: Double
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: GridexError.aiProviderError(
+                "ChatGPT provider misconfigured — OAuth service was not supplied to ProviderFactory."
+            ))
+        }
+    }
+
+    func availableModels() async throws -> [LLMModel] {
+        throw GridexError.aiProviderError(
+            "ChatGPT provider misconfigured — OAuth service was not supplied to ProviderFactory."
+        )
+    }
+
+    func validateAPIKey() async throws -> Bool {
+        throw GridexError.aiProviderError(
+            "ChatGPT provider misconfigured — OAuth service was not supplied to ProviderFactory."
+        )
     }
 }

--- a/macos/Services/AI/ProviderRegistry.swift
+++ b/macos/Services/AI/ProviderRegistry.swift
@@ -17,8 +17,17 @@ actor ProviderRegistry {
     private var entries: [String: Entry] = [:]
 
     /// Register or replace a provider by name.
-    func register(_ config: ProviderConfig, apiKey: String) {
-        let service = ProviderFactory.make(config: config, apiKey: apiKey)
+    /// Pass `chatGPTOAuthService` when `config.type == .chatGPT`; ignored otherwise.
+    func register(
+        _ config: ProviderConfig,
+        apiKey: String,
+        chatGPTOAuthService: ChatGPTOAuthService? = nil
+    ) {
+        let service = ProviderFactory.make(
+            config: config,
+            apiKey: apiKey,
+            chatGPTOAuthService: chatGPTOAuthService
+        )
         entries[config.name] = Entry(config: config, service: service)
     }
 

--- a/macos/Services/AI/Providers/ChatGPTProvider.swift
+++ b/macos/Services/AI/Providers/ChatGPTProvider.swift
@@ -1,0 +1,273 @@
+// ChatGPTProvider.swift
+// Gridex
+//
+// LLMService implementation backed by the ChatGPT subscription via the
+// Codex CLI OAuth flow. Talks to `chatgpt.com/backend-api/codex/responses`
+// (the Responses API), NOT the standard `api.openai.com/v1/chat/completions`.
+//
+// Token refresh happens lazily inside each request — see
+// `ChatGPTOAuthService.tokenBundle(...)`. The provider holds a reference to
+// the OAuth service rather than caching a token, so a refresh in one call
+// is visible to the next.
+
+import Foundation
+import os
+
+final class ChatGPTProvider: LLMService, Sendable {
+
+    private static let log = Logger(subsystem: "com.gridex.gridex", category: "ChatGPTProvider")
+
+    let providerName = "ChatGPT"
+
+    private let providerId: UUID
+    private let baseURL: String
+    private let oauthService: ChatGPTOAuthService
+    private let urlSession: URLSession
+
+    init(
+        providerId: UUID,
+        baseURL: String = ChatGPTOAuthConstants.backend.absoluteString,
+        oauthService: ChatGPTOAuthService,
+        urlSession: URLSession = .shared
+    ) {
+        self.providerId = providerId
+        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.baseURL = trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed
+        self.oauthService = oauthService
+        self.urlSession = urlSession
+    }
+
+    // MARK: - LLMService
+
+    func stream(
+        messages: [LLMMessage],
+        systemPrompt: String,
+        model: String,
+        maxTokens: Int,
+        temperature: Double
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    let bundle = try await self.oauthService.tokenBundle(providerId: self.providerId)
+                    let request = try self.buildResponsesRequest(
+                        bundle: bundle,
+                        messages: messages,
+                        systemPrompt: systemPrompt,
+                        model: model,
+                        maxTokens: maxTokens,
+                        temperature: temperature
+                    )
+
+                    let (byteStream, response) = try await self.urlSession.bytes(for: request)
+                    guard let http = response as? HTTPURLResponse else {
+                        continuation.finish(throwing: GridexError.aiStreamingError("Non-HTTP response"))
+                        return
+                    }
+                    if http.statusCode == 401 || http.statusCode == 403 {
+                        await self.clearRejectedToken(endpoint: "/responses", statusCode: http.statusCode)
+                        continuation.finish(throwing: GridexError.aiAPIKeyMissing)
+                        return
+                    }
+                    guard http.statusCode == 200 else {
+                        // Drain a bounded chunk of the body for diagnostics.
+                        var bodyBytes: [UInt8] = []
+                        for try await byte in byteStream {
+                            bodyBytes.append(byte)
+                            if bodyBytes.count > 4096 { break }
+                        }
+                        let bodyData = Data(bodyBytes)
+                        let bodyText = String(data: bodyData, encoding: .utf8) ?? ""
+                        Self.log.error("/responses HTTP \(http.statusCode) body: \(bodyText, privacy: .public)")
+                        let parsed = Self.extractErrorMessage(from: bodyData)
+                        let snippet = bodyText.prefix(300)
+                        let msg = parsed ?? "HTTP \(http.statusCode): \(snippet)"
+                        continuation.finish(throwing: GridexError.aiProviderError(msg))
+                        return
+                    }
+
+                    try await self.parseSSE(stream: byteStream, into: continuation)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    func availableModels() async throws -> [LLMModel] {
+        let bundle = try await oauthService.tokenBundle(providerId: providerId)
+        var components = URLComponents(string: "\(baseURL)/models")!
+        components.queryItems = [URLQueryItem(name: "client_version", value: "1.0.0")]
+        var request = URLRequest(url: components.url!)
+        request.setValue("Bearer \(bundle.accessToken)", forHTTPHeaderField: "Authorization")
+        if let accountId = bundle.accountId {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-ID")
+        }
+
+        let (data, http) = try await LLMRetry.perform(request, session: urlSession)
+
+        if http.statusCode == 401 || http.statusCode == 403 {
+            await clearRejectedToken(endpoint: "/models", statusCode: http.statusCode)
+            throw GridexError.aiAPIKeyMissing
+        }
+        guard http.statusCode == 200 else {
+            throw GridexError.aiProviderError("HTTP \(http.statusCode) on /models")
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw GridexError.aiProviderError("Unexpected /models response shape")
+        }
+        guard let arr = json["models"] as? [[String: Any]] else {
+            throw GridexError.aiProviderError("/models response missing 'models' array")
+        }
+
+        let visible = arr.compactMap { m -> LLMModel? in
+            guard let slug = m["slug"] as? String else { return nil }
+            // Filter to user-listable models — the API returns hidden/deprecated
+            // entries that are not actually usable through `/responses`.
+            let supported = (m["supported_in_api"] as? Bool) ?? true
+            let visibility = m["visibility"] as? String ?? "list"
+            guard supported, visibility == "list" else { return nil }
+            return LLMModel(
+                id: slug,
+                name: (m["name"] as? String) ?? slug,
+                provider: providerName,
+                contextWindow: (m["context_window"] as? Int) ?? 128_000,
+                supportsStreaming: true
+            )
+        }
+        return visible
+    }
+
+    /// Re-uses `availableModels()` as a cheap probe — a 200 there proves the
+    /// access_token is currently good. ProviderEditSheet hides the Test button
+    /// for ChatGPT, so this method is mostly here for protocol conformance + tests.
+    func validateAPIKey() async throws -> Bool {
+        _ = try await availableModels()
+        return true
+    }
+
+    // MARK: - Internal — request building
+
+    private func buildResponsesRequest(
+        bundle: ChatGPTTokenBundle,
+        messages: [LLMMessage],
+        systemPrompt: String,
+        model: String,
+        maxTokens: Int,
+        temperature: Double
+    ) throws -> URLRequest {
+        guard let url = URL(string: "\(baseURL)/responses") else {
+            throw GridexError.aiProviderError("Invalid baseURL: \(baseURL)")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(bundle.accessToken)", forHTTPHeaderField: "Authorization")
+        if let accountId = bundle.accountId {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-ID")
+        }
+        // Codex CLI sends this; harmless if the server ignores it.
+        request.setValue("responses=v1", forHTTPHeaderField: "OpenAI-Beta")
+
+        // System role → top-level `instructions`. Other roles flow into `input`.
+        // Wire format mirrors Codex CLI's actual /responses traffic:
+        //   - each input item is a typed `message` object
+        //   - content is an array of {type, text} parts (input_text / output_text)
+        //   - we DO NOT send temperature or max_output_tokens — GPT-5 family
+        //     rejects custom temperature, and Codex relies on server defaults
+        //     for output length. Sending either field returns HTTP 400.
+        let inputMessages: [[String: Any]] = messages
+            .filter { $0.role != .system }
+            .map { msg in
+                let partType = (msg.role == .assistant) ? "output_text" : "input_text"
+                return [
+                    "type": "message",
+                    "role": msg.role.rawValue,
+                    "content": [
+                        ["type": partType, "text": msg.content],
+                    ],
+                ]
+            }
+
+        let body: [String: Any] = [
+            "model":        model,
+            "instructions": systemPrompt,
+            "input":        inputMessages,
+            "stream":       true,
+            "store":        false,
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        // Body contains the user's prompt + system instructions. Logging it
+        // verbatim — even at .debug — leaks chat content to Console.app on
+        // dev builds. Only emit size/message count and non-content tuning params.
+        Self.log.debug("temperature=\(temperature) maxTokens=\(maxTokens) ignored for ChatGPT backend")
+        Self.log.debug("/responses request: \(request.httpBody?.count ?? 0) bytes, \(inputMessages.count) message(s)")
+        return request
+    }
+
+    // MARK: - Internal — SSE parsing
+
+    /// Streams `URLSession.AsyncBytes` line-by-line and yields text deltas to
+    /// the continuation. Recognises three event kinds:
+    ///   - response.output_text.delta → yield `delta` field
+    ///   - response.completed         → finish stream
+    ///   - response.error             → finish with thrown error
+    /// Other events are ignored.
+    private func parseSSE(
+        stream: URLSession.AsyncBytes,
+        into continuation: AsyncThrowingStream<String, Error>.Continuation
+    ) async throws {
+        var currentEvent: String? = nil
+
+        for try await line in stream.lines {
+            if line.isEmpty {
+                currentEvent = nil
+                continue
+            }
+            if line.hasPrefix("event: ") {
+                currentEvent = String(line.dropFirst("event: ".count))
+                continue
+            }
+            if line.hasPrefix(":") {
+                // SSE comment / keep-alive — ignore.
+                continue
+            }
+            guard line.hasPrefix("data: ") else { continue }
+            let payload = String(line.dropFirst("data: ".count))
+            if payload == "[DONE]" { break }   // not used by Responses API but harmless
+
+            guard let data = payload.data(using: .utf8) else { continue }
+
+            switch currentEvent {
+            case "response.output_text.delta":
+                if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let delta = json["delta"] as? String {
+                    continuation.yield(delta)
+                }
+            case "response.error":
+                throw GridexError.aiStreamingError(Self.extractErrorMessage(from: data) ?? payload)
+            case "response.completed":
+                return
+            default:
+                Self.log.debug("Ignoring unrecognized SSE event: \(currentEvent ?? "(none)", privacy: .public)")
+                continue
+            }
+        }
+    }
+
+    private func clearRejectedToken(endpoint: String, statusCode: Int) async {
+        Self.log.notice("\(endpoint, privacy: .public) returned \(statusCode); clearing ChatGPT token bundle")
+        try? await oauthService.signOut(providerId: providerId)
+    }
+
+    /// Pull a human-readable error message out of a Responses-API JSON body,
+    /// in either nested (`{"error":{"message":...}}`) or flat (`{"message":...}`)
+    /// form. Returns nil when the body isn't JSON or has neither shape.
+    private static func extractErrorMessage(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        if let err = json["error"] as? [String: Any], let m = err["message"] as? String { return m }
+        return json["message"] as? String
+    }
+}

--- a/macos/Tests/GridexTests/ChatGPTOAuthServiceTests.swift
+++ b/macos/Tests/GridexTests/ChatGPTOAuthServiceTests.swift
@@ -1,0 +1,601 @@
+// ChatGPTOAuthServiceTests.swift
+// Gridex
+//
+// Mocked-network tests for ChatGPTOAuthService.tokenBundle(...) refresh path:
+//   1. Concurrent calls with an expired access_token coalesce into ONE
+//      auth.openai.com round-trip (per-providerId in-flight de-dup).
+//   2. `error: refresh_token_expired` from the server clears the keychain
+//      blob and surfaces aiAPIKeyMissing for the caller to prompt re-login.
+//   3. A 200 response without `refresh_token` keeps the previously-stored one
+//      (server may rotate, may not — we mustn't drop it).
+//
+// We do not exercise the interactive `signIn(...)` path here — that opens
+// NSWorkspace + the loopback server, which is end-to-end manual territory.
+
+import XCTest
+@testable import Gridex
+
+final class ChatGPTOAuthServiceTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: - 1. Concurrent refresh de-duplication
+
+    func test_concurrentTokenBundle_coalescesToSingleRefresh() async throws {
+        let providerId = UUID()
+        let keychain = MockKeychain()
+        keychain.bundle = Self.makeExpiredBundle()
+
+        // Server takes 200ms to respond, giving every concurrent caller a
+        // chance to race into refreshInFlight before the first task finishes.
+        MockURLProtocol.responseDelay = 0.2
+        MockURLProtocol.responder = { _ in
+            let body = Self.tokenJSON(
+                accessToken: Self.freshAccessJWT(),
+                refreshToken: "rotated-refresh",
+                idToken: Self.idJWTFixture()
+            )
+            return (Self.okResponse(), body)
+        }
+
+        let service = ChatGPTOAuthService(
+            keychainService: keychain,
+            urlSession: Self.mockedSession()
+        )
+
+        // Fan out 5 concurrent calls. All 5 must succeed; the server must
+        // see exactly 1 hit (the actor coalesces the rest onto the same Task).
+        try await withThrowingTaskGroup(of: ChatGPTTokenBundle.self) { group in
+            for _ in 0..<5 {
+                group.addTask { try await service.tokenBundle(providerId: providerId) }
+            }
+            var results: [ChatGPTTokenBundle] = []
+            for try await b in group { results.append(b) }
+            XCTAssertEqual(results.count, 5)
+            for b in results {
+                XCTAssertEqual(b.refreshToken, "rotated-refresh", "all callers see the rotated token")
+            }
+        }
+
+        XCTAssertEqual(MockURLProtocol.requestCount, 1,
+                       "5 concurrent calls must collapse into a single refresh request")
+    }
+
+    // MARK: - 2. Refresh-token-expired path
+
+    func test_refreshTokenExpired_clearsKeychainAndThrowsAPIKeyMissing() async throws {
+        let providerId = UUID()
+        let keychain = MockKeychain()
+        keychain.bundle = Self.makeExpiredBundle()
+
+        MockURLProtocol.responder = { _ in
+            let body = Data(#"{"error":"refresh_token_expired","error_description":"jwt is expired"}"#.utf8)
+            return (Self.errorResponse(status: 400), body)
+        }
+
+        let service = ChatGPTOAuthService(
+            keychainService: keychain,
+            urlSession: Self.mockedSession()
+        )
+
+        do {
+            _ = try await service.tokenBundle(providerId: providerId)
+            XCTFail("expected aiAPIKeyMissing to be thrown")
+        } catch GridexError.aiAPIKeyMissing {
+            // expected
+        } catch {
+            XCTFail("expected aiAPIKeyMissing, got \(error)")
+        }
+
+        XCTAssertNil(keychain.bundle, "expired refresh_token must purge the keychain blob")
+    }
+
+    // MARK: - 3. Optional refresh_token preservation
+
+    func test_refreshSuccessWithoutRotation_keepsOldRefreshToken() async throws {
+        let providerId = UUID()
+        let keychain = MockKeychain()
+        let original = Self.makeExpiredBundle(refreshToken: "original-refresh")
+        keychain.bundle = original
+
+        MockURLProtocol.responder = { _ in
+            // Server rotates access_token + id_token but omits refresh_token.
+            let body = Self.tokenJSON(
+                accessToken: Self.freshAccessJWT(),
+                refreshToken: nil,
+                idToken: Self.idJWTFixture()
+            )
+            return (Self.okResponse(), body)
+        }
+
+        let service = ChatGPTOAuthService(
+            keychainService: keychain,
+            urlSession: Self.mockedSession()
+        )
+
+        let updated = try await service.tokenBundle(providerId: providerId)
+        XCTAssertEqual(updated.refreshToken, "original-refresh",
+                       "missing refresh_token in response must keep the old one")
+        XCTAssertNotEqual(updated.accessToken, original.accessToken,
+                          "access_token should still be rotated")
+    }
+
+    // MARK: - 4. Provider auth rejection cleanup
+
+    func test_streamUnauthorized_clearsKeychainAndThrowsAPIKeyMissing() async throws {
+        let providerId = UUID()
+        let keychain = MockKeychain()
+        keychain.bundle = Self.makeFreshBundle()
+
+        MockURLProtocol.responder = { _ in
+            let body = Data(#"{"error":{"message":"unauthorized"}}"#.utf8)
+            return (Self.errorResponse(status: 401), body)
+        }
+
+        let service = ChatGPTOAuthService(
+            keychainService: keychain,
+            urlSession: Self.mockedSession()
+        )
+        let provider = ChatGPTProvider(
+            providerId: providerId,
+            oauthService: service,
+            urlSession: Self.mockedSession()
+        )
+
+        do {
+            var iterator = provider.stream(
+                messages: [LLMMessage(role: .user, content: "hi")],
+                systemPrompt: "",
+                model: "gpt-test",
+                maxTokens: 1,
+                temperature: 0
+            ).makeAsyncIterator()
+            _ = try await iterator.next()
+            XCTFail("expected aiAPIKeyMissing")
+        } catch GridexError.aiAPIKeyMissing {
+            // expected
+        } catch {
+            XCTFail("expected aiAPIKeyMissing, got \(error)")
+        }
+
+        XCTAssertNil(keychain.bundle, "401 from /responses must clear the stale bundle")
+    }
+
+    func test_availableModelsForbidden_clearsKeychainAndThrowsAPIKeyMissing() async throws {
+        let providerId = UUID()
+        let keychain = MockKeychain()
+        keychain.bundle = Self.makeFreshBundle()
+
+        MockURLProtocol.responder = { _ in
+            let body = Data(#"{"error":{"message":"forbidden"}}"#.utf8)
+            return (Self.errorResponse(status: 403), body)
+        }
+
+        let service = ChatGPTOAuthService(
+            keychainService: keychain,
+            urlSession: Self.mockedSession()
+        )
+        let provider = ChatGPTProvider(
+            providerId: providerId,
+            oauthService: service,
+            urlSession: Self.mockedSession()
+        )
+
+        do {
+            _ = try await provider.availableModels()
+            XCTFail("expected aiAPIKeyMissing")
+        } catch GridexError.aiAPIKeyMissing {
+            // expected
+        } catch {
+            XCTFail("expected aiAPIKeyMissing, got \(error)")
+        }
+
+        XCTAssertNil(keychain.bundle, "403 from /models must clear the stale bundle")
+    }
+
+    // MARK: - 5. tokenBundle short-circuit + missing keychain
+
+    /// A non-expired access_token must NOT trigger a refresh round-trip — every
+    /// production request hits this path. Regression here means we'd hammer
+    /// auth.openai.com on every call and risk being rate-limited.
+    func test_tokenBundle_freshToken_skipsNetworkRefresh() async throws {
+        let providerId = UUID()
+        let keychain = MockKeychain()
+        keychain.bundle = Self.makeFreshBundle(refreshToken: "kept-refresh")
+
+        MockURLProtocol.responder = { _ in
+            XCTFail("fresh token must not hit auth.openai.com")
+            return (Self.errorResponse(status: 500), Data())
+        }
+
+        let service = ChatGPTOAuthService(
+            keychainService: keychain,
+            urlSession: Self.mockedSession()
+        )
+
+        let bundle = try await service.tokenBundle(providerId: providerId)
+        XCTAssertEqual(bundle.refreshToken, "kept-refresh")
+        XCTAssertEqual(MockURLProtocol.requestCount, 0,
+                       "non-expired token must not trigger refresh")
+    }
+
+    /// When the user added a ChatGPT provider row but never completed sign-in,
+    /// `tokenBundle()` must surface `aiAPIKeyMissing` so the UI can prompt for
+    /// re-login. DependencyContainer.bootstrap relies on this contract.
+    func test_tokenBundle_missingKeychain_throwsAPIKeyMissing() async throws {
+        let providerId = UUID()
+        let keychain = MockKeychain()
+
+        let service = ChatGPTOAuthService(
+            keychainService: keychain,
+            urlSession: Self.mockedSession()
+        )
+
+        do {
+            _ = try await service.tokenBundle(providerId: providerId)
+            XCTFail("expected aiAPIKeyMissing")
+        } catch GridexError.aiAPIKeyMissing {
+            // expected
+        } catch {
+            XCTFail("expected aiAPIKeyMissing, got \(error)")
+        }
+
+        XCTAssertEqual(MockURLProtocol.requestCount, 0,
+                       "must not call auth.openai.com when no bundle exists")
+    }
+
+    // MARK: - 6. ChatGPTProvider SSE streaming
+
+    /// Locks the SSE happy path — accumulating deltas and finishing on
+    /// `response.completed`. This is ChatGPTProvider's core contract; without
+    /// this test a regression in `parseSSE` would silently drop tokens or
+    /// hang forever, and only end-to-end testing would catch it.
+    func test_streamHappyPath_yieldsDeltasAndFinishes() async throws {
+        let providerId = UUID()
+        let keychain = MockKeychain()
+        keychain.bundle = Self.makeFreshBundle()
+
+        // SSE wire format: `event: …\ndata: …` followed by a blank line that
+        // terminates the event. The two trailing blank lines below are
+        // load-bearing — the second one terminates `response.completed`.
+        let sse = """
+        event: response.output_text.delta
+        data: {"delta":"Hello"}
+
+        event: response.output_text.delta
+        data: {"delta":", "}
+
+        event: response.output_text.delta
+        data: {"delta":"world"}
+
+        event: response.completed
+        data: {}
+
+
+        """
+
+        MockURLProtocol.responder = { _ in
+            (Self.sseResponse(), Data(sse.utf8))
+        }
+
+        let service = ChatGPTOAuthService(
+            keychainService: keychain,
+            urlSession: Self.mockedSession()
+        )
+        let provider = ChatGPTProvider(
+            providerId: providerId,
+            oauthService: service,
+            urlSession: Self.mockedSession()
+        )
+
+        var collected = ""
+        for try await chunk in provider.stream(
+            messages: [LLMMessage(role: .user, content: "hi")],
+            systemPrompt: "",
+            model: "gpt-test",
+            maxTokens: 1,
+            temperature: 0
+        ) {
+            collected += chunk
+        }
+        XCTAssertEqual(collected, "Hello, world",
+                       "deltas must concatenate in arrival order")
+    }
+
+    /// `response.error` events must surface as `aiStreamingError` with the
+    /// server's message. The chat UI depends on this to render rate-limit /
+    /// content-policy failures inline rather than as a generic crash.
+    func test_streamErrorEvent_throwsStreamingError() async throws {
+        let providerId = UUID()
+        let keychain = MockKeychain()
+        keychain.bundle = Self.makeFreshBundle()
+
+        // Trailing blank line terminates the `response.error` event.
+        let sse = """
+        event: response.error
+        data: {"message":"rate limited"}
+
+
+        """
+
+        MockURLProtocol.responder = { _ in
+            (Self.sseResponse(), Data(sse.utf8))
+        }
+
+        let service = ChatGPTOAuthService(
+            keychainService: keychain,
+            urlSession: Self.mockedSession()
+        )
+        let provider = ChatGPTProvider(
+            providerId: providerId,
+            oauthService: service,
+            urlSession: Self.mockedSession()
+        )
+
+        do {
+            for try await _ in provider.stream(
+                messages: [LLMMessage(role: .user, content: "hi")],
+                systemPrompt: "",
+                model: "gpt-test",
+                maxTokens: 1,
+                temperature: 0
+            ) {}
+            XCTFail("expected aiStreamingError")
+        } catch let GridexError.aiStreamingError(message) {
+            XCTAssertEqual(message, "rate limited",
+                           "server's error message must propagate to caller")
+        } catch {
+            XCTFail("expected aiStreamingError, got \(error)")
+        }
+    }
+
+    // MARK: - 7. availableModels filtering
+
+    /// Locks the list-filter contract — `supported_in_api == false` and
+    /// `visibility != "list"` rows must be dropped. Server returns hidden /
+    /// deprecated entries; without this filter the UI's model picker would
+    /// surface unusable slugs that 400 on /responses.
+    func test_availableModels_filtersHiddenAndUnsupported() async throws {
+        let providerId = UUID()
+        let keychain = MockKeychain()
+        keychain.bundle = Self.makeFreshBundle()
+
+        let body: [String: Any] = [
+            "models": [
+                ["slug": "gpt-5", "name": "GPT-5",
+                 "supported_in_api": true, "visibility": "list",
+                 "context_window": 200_000],
+                ["slug": "gpt-internal", "name": "Internal",
+                 "supported_in_api": true, "visibility": "hidden"],
+                ["slug": "gpt-deprecated", "name": "Old",
+                 "supported_in_api": false, "visibility": "list"],
+                ["slug": "gpt-mini", "name": "GPT-mini",
+                 "supported_in_api": true, "visibility": "list"],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: body)
+
+        MockURLProtocol.responder = { _ in
+            (Self.modelsResponse(), data)
+        }
+
+        let service = ChatGPTOAuthService(
+            keychainService: keychain,
+            urlSession: Self.mockedSession()
+        )
+        let provider = ChatGPTProvider(
+            providerId: providerId,
+            oauthService: service,
+            urlSession: Self.mockedSession()
+        )
+
+        let models = try await provider.availableModels()
+        XCTAssertEqual(Set(models.map(\.id)), Set(["gpt-5", "gpt-mini"]),
+                       "only supported + visible='list' models survive")
+        XCTAssertEqual(models.first(where: { $0.id == "gpt-5" })?.contextWindow,
+                       200_000,
+                       "context_window from response must propagate")
+    }
+
+    // MARK: - 8. Loopback callback ordering
+
+    func test_loopbackCallbackBeforeAwait_isBuffered() async throws {
+        let server = ChatGPTOAuthLoopbackServer()
+        let port = try await server.start(preferredPorts: [])
+        defer { server.stop() }
+
+        let url = URL(string: "http://127.0.0.1:\(port)\(ChatGPTOAuthConstants.callbackPath)?code=early-code&state=early-state")!
+        _ = try await URLSession.shared.data(from: url)
+
+        let callback = try await server.awaitCallback(timeout: 1)
+        XCTAssertEqual(callback.code, "early-code")
+        XCTAssertEqual(callback.state, "early-state")
+    }
+
+    // MARK: - Fixtures
+
+    /// In-memory `ChatGPTTokenBundle` JWT fixtures encode the same exp claim
+    /// the service inspects via JWTDecoder. Header is `{"alg":"none"}`.
+    private static func makeJWT(payload: String) -> String {
+        let header = #"{"alg":"none","typ":"JWT"}"#
+        let h = PKCE.base64URL(Data(header.utf8))
+        let p = PKCE.base64URL(Data(payload.utf8))
+        return "\(h).\(p)."
+    }
+
+    /// access_token whose exp is 60s in the past — guaranteed to trigger refresh.
+    private static func expiredAccessJWT() -> String {
+        let exp = Int(Date().addingTimeInterval(-60).timeIntervalSince1970)
+        return makeJWT(payload: #"{"exp":\#(exp),"sub":"u"}"#)
+    }
+
+    /// access_token with exp 1 hour in the future. Keeps tests deterministic.
+    private static func freshAccessJWT() -> String {
+        let exp = Int(Date().addingTimeInterval(3600).timeIntervalSince1970)
+        return makeJWT(payload: #"{"exp":\#(exp),"sub":"u"}"#)
+    }
+
+    private static func idJWTFixture() -> String {
+        makeJWT(payload: #"{"email":"u@example.com","chatgpt_account_id":"acc","chatgpt_plan_type":"plus"}"#)
+    }
+
+    private static func makeExpiredBundle(refreshToken: String = "old-refresh") -> ChatGPTTokenBundle {
+        ChatGPTTokenBundle(
+            accessToken: expiredAccessJWT(),
+            refreshToken: refreshToken,
+            idToken: idJWTFixture(),
+            accountId: "acc",
+            email: "u@example.com",
+            planType: "plus",
+            obtainedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
+    private static func makeFreshBundle(refreshToken: String = "old-refresh") -> ChatGPTTokenBundle {
+        ChatGPTTokenBundle(
+            accessToken: freshAccessJWT(),
+            refreshToken: refreshToken,
+            idToken: idJWTFixture(),
+            accountId: "acc",
+            email: "u@example.com",
+            planType: "plus",
+            obtainedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
+    private static func tokenJSON(accessToken: String, refreshToken: String?, idToken: String) -> Data {
+        var dict: [String: Any] = ["access_token": accessToken, "id_token": idToken]
+        if let refreshToken { dict["refresh_token"] = refreshToken }
+        return try! JSONSerialization.data(withJSONObject: dict)
+    }
+
+    private static func okResponse() -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://auth.openai.com/oauth/token")!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private static func errorResponse(status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://auth.openai.com/oauth/token")!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private static func sseResponse() -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://chatgpt.com/backend-api/codex/responses")!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/event-stream"]
+        )!
+    }
+
+    private static func modelsResponse() -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://chatgpt.com/backend-api/codex/models")!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+
+    private static func mockedSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+}
+
+// MARK: - Mock keychain (in-memory, single-bundle)
+
+private final class MockKeychain: KeychainServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _bundle: ChatGPTTokenBundle?
+
+    var bundle: ChatGPTTokenBundle? {
+        get { lock.lock(); defer { lock.unlock() }; return _bundle }
+        set { lock.lock(); defer { lock.unlock() }; _bundle = newValue }
+    }
+
+    func save(key: String, value: String) throws { fatalError("unused in these tests") }
+    func load(key: String) throws -> String? { fatalError("unused in these tests") }
+    func delete(key: String) throws { fatalError("unused in these tests") }
+    func update(key: String, value: String) throws { fatalError("unused in these tests") }
+
+    func saveChatGPTTokens(providerId: UUID, bundle: ChatGPTTokenBundle) throws {
+        self.bundle = bundle
+    }
+
+    func loadChatGPTTokens(providerId: UUID) throws -> ChatGPTTokenBundle? {
+        self.bundle
+    }
+
+    func deleteChatGPTTokens(providerId: UUID) throws {
+        self.bundle = nil
+    }
+}
+
+// MARK: - Mock URLProtocol
+
+/// URLSession passes every request through this protocol when attached to the
+/// session config. We track call count + emit canned responses so the service
+/// thinks it's talking to auth.openai.com.
+private final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requestCount: Int = 0
+    nonisolated(unsafe) static var responseDelay: TimeInterval = 0
+    nonisolated(unsafe) static var responder: ((URLRequest) -> (HTTPURLResponse, Data))?
+    private static let lock = NSLock()
+
+    static func reset() {
+        lock.lock(); defer { lock.unlock() }
+        requestCount = 0
+        responseDelay = 0
+        responder = nil
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.lock()
+        Self.requestCount += 1
+        let responder = Self.responder
+        let delay = Self.responseDelay
+        Self.lock.unlock()
+
+        let work: @Sendable () -> Void = { [weak self] in
+            guard let self else { return }
+            guard let responder else {
+                let err = NSError(domain: "MockURLProtocolNoResponder", code: -1)
+                self.client?.urlProtocol(self, didFailWithError: err)
+                return
+            }
+            let (response, data) = responder(self.request)
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        }
+
+        if delay > 0 {
+            DispatchQueue.global().asyncAfter(deadline: .now() + delay, execute: work)
+        } else {
+            DispatchQueue.global().async(execute: work)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/macos/Tests/GridexTests/ChatGPTOAuthTests.swift
+++ b/macos/Tests/GridexTests/ChatGPTOAuthTests.swift
@@ -1,0 +1,282 @@
+// ChatGPTOAuthTests.swift — pure-logic tests for the ChatGPT OAuth foundation.
+// Covers PKCE primitives, JWT payload decoding, and token bundle round-trips.
+// The interactive sign-in flow + live HTTP refresh land in PR 2 with their own
+// URL-protocol-mocked tests.
+
+import XCTest
+@testable import Gridex
+
+final class ChatGPTOAuthTests: XCTestCase {
+
+    // MARK: - Keychain fixture
+
+    private var keychain: KeychainService!
+    private var trackedProviderIds: [UUID] = []
+
+    override func setUp() {
+        super.setUp()
+        keychain = KeychainService()
+    }
+
+    override func tearDown() {
+        trackedProviderIds.forEach { try? keychain.deleteChatGPTTokens(providerId: $0) }
+        trackedProviderIds.removeAll()
+        keychain = nil
+        super.tearDown()
+    }
+
+    /// Mints a fresh provider UUID and registers it for tearDown cleanup, so the
+    /// test body doesn't need its own `defer { try? keychain.delete... }`.
+    private func makeProviderId() -> UUID {
+        let id = UUID()
+        trackedProviderIds.append(id)
+        return id
+    }
+
+    // MARK: - PKCE
+
+    func test_makeVerifier_returns43CharBase64URL() {
+        let v = PKCE.makeVerifier()
+        // 32 bytes → 43 base64url chars (no padding)
+        XCTAssertEqual(v.count, 43, "verifier should be 43 chars")
+        XCTAssertFalse(v.contains("="), "no padding")
+        XCTAssertFalse(v.contains("+"), "URL-safe alphabet only")
+        XCTAssertFalse(v.contains("/"), "URL-safe alphabet only")
+    }
+
+    func test_makeVerifier_isUniquePerCall() {
+        let a = PKCE.makeVerifier()
+        let b = PKCE.makeVerifier()
+        XCTAssertNotEqual(a, b, "CSPRNG should not repeat in 32 bytes of entropy")
+    }
+
+    /// RFC 7636 Appendix B test vector — locks the SHA256 + base64url contract.
+    func test_challenge_matchesRFC7636Vector() {
+        let verifier  = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        let expected  = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        XCTAssertEqual(PKCE.challenge(for: verifier), expected)
+    }
+
+    func test_makeState_returns43CharBase64URL() {
+        let s = PKCE.makeState()
+        XCTAssertEqual(s.count, 43)
+        XCTAssertFalse(s.contains("="))
+    }
+
+    func test_base64URL_strippsPaddingAndSubstitutes() {
+        // 1 byte → "AA==" in standard base64. URL-safe variant: "AA".
+        XCTAssertEqual(PKCE.base64URL(Data([0])), "AA")
+        // Two bytes hitting a "+" in standard base64.
+        // 0xFB 0xFF → "+/8=" → "-_8" after URL-safe + strip.
+        XCTAssertEqual(PKCE.base64URL(Data([0xFB, 0xFF])), "-_8")
+    }
+
+    // MARK: - JWTDecoder
+
+    /// A hand-crafted unsigned JWT whose payload is `{"exp":1700000000,"sub":"abc","email":"u@example.com"}`.
+    /// Header `{"alg":"none","typ":"JWT"}`, signature segment empty.
+    private static let fixtureJWT: String = {
+        let header  = #"{"alg":"none","typ":"JWT"}"#
+        let payload = #"{"exp":1700000000,"sub":"abc","email":"u@example.com"}"#
+        let h = PKCE.base64URL(Data(header.utf8))
+        let p = PKCE.base64URL(Data(payload.utf8))
+        return "\(h).\(p)."
+    }()
+
+    func test_jwtPayload_decodesClaims() throws {
+        let claims = try JWTDecoder.payload(of: Self.fixtureJWT)
+        XCTAssertEqual(claims["sub"] as? String, "abc")
+        XCTAssertEqual(claims["email"] as? String, "u@example.com")
+        XCTAssertEqual(claims["exp"] as? Int, 1700000000)
+    }
+
+    func test_jwtExpiration_returnsCorrectDate() throws {
+        let date = try XCTUnwrap(JWTDecoder.expiration(of: Self.fixtureJWT))
+        XCTAssertEqual(date.timeIntervalSince1970, 1700000000, accuracy: 0.001)
+    }
+
+    func test_jwtPayload_throwsOnMalformedSegmentCount() {
+        XCTAssertThrowsError(try JWTDecoder.payload(of: "only.two")) { error in
+            guard case JWTDecoder.DecodeError.malformed = error else {
+                return XCTFail("expected malformed error, got \(error)")
+            }
+        }
+    }
+
+    func test_jwtPayload_throwsOnInvalidBase64() {
+        XCTAssertThrowsError(try JWTDecoder.payload(of: "header.@@@.sig"))
+    }
+
+    func test_jwtPayload_throwsWhenPayloadIsNotObject() throws {
+        // Payload "[]" is valid JSON but not an object.
+        let header = PKCE.base64URL(Data(#"{"alg":"none"}"#.utf8))
+        let body   = PKCE.base64URL(Data("[]".utf8))
+        XCTAssertThrowsError(try JWTDecoder.payload(of: "\(header).\(body)."))
+    }
+
+    func test_jwtExpiration_returnsNilWhenClaimMissing() {
+        let header = PKCE.base64URL(Data(#"{"alg":"none"}"#.utf8))
+        let body   = PKCE.base64URL(Data(#"{"sub":"x"}"#.utf8))
+        let jwt    = "\(header).\(body)."
+        XCTAssertNil(JWTDecoder.expiration(of: jwt))
+    }
+
+    // MARK: - ChatGPTTokenBundle
+
+    func test_tokenBundle_codableRoundTrip() throws {
+        let original = ChatGPTTokenBundle(
+            accessToken: "access.jwt.value",
+            refreshToken: "refresh.jwt.value",
+            idToken: "id.jwt.value",
+            accountId: "acc_123",
+            email: "u@example.com",
+            planType: "plus",
+            obtainedAt: Date(timeIntervalSince1970: 1700000000),
+            schemaVersion: 1
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(ChatGPTTokenBundle.self, from: data)
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    func test_tokenBundle_optionalFieldsRoundTrip() throws {
+        let original = ChatGPTTokenBundle(
+            accessToken: "a", refreshToken: "r", idToken: "i"
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(original)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(ChatGPTTokenBundle.self, from: data)
+
+        XCTAssertNil(decoded.accountId)
+        XCTAssertNil(decoded.email)
+        XCTAssertNil(decoded.planType)
+        XCTAssertEqual(decoded.schemaVersion, 1)
+    }
+
+    // MARK: - Keychain helpers
+
+    func test_keychain_chatGPTTokens_roundTrip() throws {
+        let providerId = makeProviderId()
+
+        // Pre-condition: nothing stored yet.
+        XCTAssertNil(try keychain.loadChatGPTTokens(providerId: providerId))
+
+        let bundle = ChatGPTTokenBundle(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: "id",
+            accountId: "acc",
+            email: "u@example.com",
+            planType: "pro",
+            obtainedAt: Date(timeIntervalSince1970: 1700000000)
+        )
+        try keychain.saveChatGPTTokens(providerId: providerId, bundle: bundle)
+
+        let loaded = try keychain.loadChatGPTTokens(providerId: providerId)
+        XCTAssertEqual(loaded, bundle)
+
+        try keychain.deleteChatGPTTokens(providerId: providerId)
+        XCTAssertNil(try keychain.loadChatGPTTokens(providerId: providerId))
+    }
+
+    /// Locks the per-provider key namespacing — saving under one UUID must not
+    /// be visible under another, and deleting under an unrelated UUID must not
+    /// touch the original. Guards against a future regression where someone
+    /// accidentally drops the UUID from the key (sharing a single slot).
+    func test_keychain_chatGPTTokens_isolatedAcrossProviders() throws {
+        let providerA = makeProviderId()
+        let providerB = makeProviderId()
+
+        let bundleA = ChatGPTTokenBundle(
+            accessToken: "A", refreshToken: "rA", idToken: "iA",
+            obtainedAt: Date(timeIntervalSince1970: 1700000000)
+        )
+        try keychain.saveChatGPTTokens(providerId: providerA, bundle: bundleA)
+
+        XCTAssertNil(
+            try keychain.loadChatGPTTokens(providerId: providerB),
+            "loading under providerB must not see providerA's bundle"
+        )
+
+        try keychain.deleteChatGPTTokens(providerId: providerB)
+        XCTAssertEqual(
+            try keychain.loadChatGPTTokens(providerId: providerA),
+            bundleA,
+            "delete on providerB must not touch providerA's bundle"
+        )
+    }
+
+    /// Locks "second save fully replaces the first" — this is the production
+    /// path used by every token refresh in `ChatGPTOAuthService.performRefresh`.
+    /// A regression where save somehow merged or appended would corrupt the
+    /// bundle silently; this test catches that.
+    func test_keychain_chatGPTTokens_overwriteReplacesPriorValue() throws {
+        let providerId = makeProviderId()
+
+        let first = ChatGPTTokenBundle(
+            accessToken: "old", refreshToken: "old-r", idToken: "old-i",
+            accountId: "acc-old",
+            email: "old@example.com",
+            planType: "plus",
+            obtainedAt: Date(timeIntervalSince1970: 1700000000)
+        )
+        let second = ChatGPTTokenBundle(
+            accessToken: "new", refreshToken: "new-r", idToken: "new-i",
+            accountId: "acc-new",
+            email: "new@example.com",
+            planType: "pro",
+            obtainedAt: Date(timeIntervalSince1970: 1700001000)
+        )
+
+        try keychain.saveChatGPTTokens(providerId: providerId, bundle: first)
+        try keychain.saveChatGPTTokens(providerId: providerId, bundle: second)
+
+        let loaded = try keychain.loadChatGPTTokens(providerId: providerId)
+        XCTAssertEqual(loaded, second, "second save must fully replace the first")
+    }
+
+    /// Locks the current `dateEncodingStrategy = .iso8601` contract:
+    /// `ISO8601DateFormatter` defaults to `[.withInternetDateTime]` (no
+    /// fractional seconds), so `obtainedAt` round-trips truncated to whole
+    /// seconds. This is harmless today (`ChatGPTOAuthService` uses JWT `exp`
+    /// for refresh timing, not `obtainedAt`, and never compares bundles for
+    /// equality), but if a future change starts depending on subsecond
+    /// precision, this test will fire and flag that the encoding strategy
+    /// needs `.withFractionalSeconds`.
+    func test_keychain_chatGPTTokens_obtainedAtRoundTripStripsSubseconds() throws {
+        let providerId = makeProviderId()
+
+        // 0.123s past a whole-second boundary — small enough that any rounding
+        // mode (truncate or round-to-nearest) lands on the floor value.
+        let originalTs: TimeInterval = 1700000000.123
+        let bundle = ChatGPTTokenBundle(
+            accessToken: "a", refreshToken: "r", idToken: "i",
+            obtainedAt: Date(timeIntervalSince1970: originalTs)
+        )
+
+        try keychain.saveChatGPTTokens(providerId: providerId, bundle: bundle)
+        let loaded = try XCTUnwrap(try keychain.loadChatGPTTokens(providerId: providerId))
+
+        XCTAssertEqual(
+            loaded.obtainedAt.timeIntervalSince1970,
+            1700000000.0,
+            accuracy: 0.0001,
+            "iso8601 default options drop fractional seconds"
+        )
+        XCTAssertNotEqual(
+            loaded.obtainedAt,
+            bundle.obtainedAt,
+            "Equatable should detect the subsecond loss — if this fails, the encoding has gained fractional-second precision and this test should become an equality assertion"
+        )
+    }
+}

--- a/macos/Tests/GridexTests/ProviderFactoryTests.swift
+++ b/macos/Tests/GridexTests/ProviderFactoryTests.swift
@@ -88,21 +88,12 @@ final class ProviderFactoryTests: XCTestCase {
         XCTAssertTrue(service is OpenAIProvider)
     }
 
-    // MARK: - Default model for .chatGPT must be a real slug
+    // MARK: - Default model for .chatGPT
 
-    // Regression for the `defaultModel = "gpt-5.4"` bug — that slug doesn't
-    // exist server-side, so a freshly-created ChatGPT provider fired a request
-    // before the live `/models` picker resolved would 400 immediately.
-    func test_defaultModel_chatGPT_isRealisticSlug() {
-        let model = ProviderType.chatGPT.defaultModel
-        XCTAssertFalse(model.isEmpty, "ChatGPT default model must be set")
-        // Avoid the literal regression: invented "gpt-X.Y" decimal slugs.
-        XCTAssertFalse(model.contains("gpt-5.4"), "must not use the invented 'gpt-5.4' slug")
-        // Codex CLI uses gpt-5-codex; either that or another known-real slug
-        // (gpt-5, gpt-5-codex variants) is acceptable.
-        XCTAssertTrue(
-            model.hasPrefix("gpt-5") || model == "gpt-4o",
-            "default must be a known-real OpenAI model slug, got: \(model)"
-        )
+    func test_defaultModel_chatGPT_isNonEmpty() {
+        // The authoritative slug list comes from `/backend-api/codex/models`
+        // after sign-in. The default just needs to be non-empty so the form
+        // has something to send before the live picker resolves.
+        XCTAssertFalse(ProviderType.chatGPT.defaultModel.isEmpty)
     }
 }

--- a/macos/Tests/GridexTests/ProviderFactoryTests.swift
+++ b/macos/Tests/GridexTests/ProviderFactoryTests.swift
@@ -1,0 +1,108 @@
+// ProviderFactoryTests.swift
+//
+// Pin the dispatch behaviour of ProviderFactory.make so a future contributor
+// can't silently break the .chatGPT case (e.g. by flipping a switch label,
+// or by reaching for the legacy `make(type:apiKey:baseURL:)` overload that
+// can't thread an OAuth service through).
+
+import XCTest
+@testable import Gridex
+
+final class ProviderFactoryTests: XCTestCase {
+
+    // MARK: - .chatGPT dispatch
+
+    func test_make_returnsChatGPTProvider_whenOAuthServiceProvided() {
+        let oauth = ChatGPTOAuthService(
+            keychainService: KeychainService(),
+            urlSession: .shared
+        )
+        let config = ProviderConfig(name: "ChatGPT", type: .chatGPT)
+
+        let service = ProviderFactory.make(
+            config: config,
+            apiKey: "",
+            chatGPTOAuthService: oauth
+        )
+
+        XCTAssertTrue(service is ChatGPTProvider,
+            "with OAuth service supplied, factory must return a real ChatGPTProvider")
+    }
+
+    func test_make_returnsMisconfiguredStub_whenOAuthServiceMissing() {
+        // Reachable from `make(type:apiKey:baseURL:)` (legacy / DependencyContainer
+        // path) which never threads chatGPTOAuthService through.
+        let config = ProviderConfig(name: "ChatGPT", type: .chatGPT)
+        let service = ProviderFactory.make(config: config, apiKey: "")
+
+        // Stub is private; verify by behaviour: every call must throw GridexError.
+        // (Pre-fix this code-path was preconditionFailure → process crash.)
+        let stream = service.stream(
+            messages: [],
+            systemPrompt: "",
+            model: "gpt-5-codex",
+            maxTokens: 100,
+            temperature: 1.0
+        )
+
+        let exp = expectation(description: "stream throws aiProviderError")
+        Task {
+            do {
+                for try await _ in stream {}
+                XCTFail("misconfigured stub must not yield values")
+            } catch let GridexError.aiProviderError(msg) {
+                XCTAssertTrue(msg.contains("misconfigured"), "got: \(msg)")
+                exp.fulfill()
+            } catch {
+                XCTFail("expected GridexError.aiProviderError, got \(error)")
+            }
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    func test_make_misconfiguredStub_availableModelsThrows() async {
+        let config = ProviderConfig(name: "ChatGPT", type: .chatGPT)
+        let service = ProviderFactory.make(config: config, apiKey: "")
+
+        do {
+            _ = try await service.availableModels()
+            XCTFail("availableModels must throw when ChatGPT factory is misconfigured")
+        } catch let GridexError.aiProviderError(msg) {
+            XCTAssertTrue(msg.contains("misconfigured"))
+        } catch {
+            XCTFail("expected GridexError.aiProviderError, got \(error)")
+        }
+    }
+
+    // MARK: - Other providers route correctly
+
+    func test_make_anthropic_returnsAnthropicProvider() {
+        let config = ProviderConfig(name: "Anthropic", type: .anthropic)
+        let service = ProviderFactory.make(config: config, apiKey: "sk-test")
+        XCTAssertTrue(service is AnthropicProvider)
+    }
+
+    func test_make_openAI_returnsOpenAIProvider() {
+        let config = ProviderConfig(name: "OpenAI", type: .openAI)
+        let service = ProviderFactory.make(config: config, apiKey: "sk-test")
+        XCTAssertTrue(service is OpenAIProvider)
+    }
+
+    // MARK: - Default model for .chatGPT must be a real slug
+
+    // Regression for the `defaultModel = "gpt-5.4"` bug — that slug doesn't
+    // exist server-side, so a freshly-created ChatGPT provider fired a request
+    // before the live `/models` picker resolved would 400 immediately.
+    func test_defaultModel_chatGPT_isRealisticSlug() {
+        let model = ProviderType.chatGPT.defaultModel
+        XCTAssertFalse(model.isEmpty, "ChatGPT default model must be set")
+        // Avoid the literal regression: invented "gpt-X.Y" decimal slugs.
+        XCTAssertFalse(model.contains("gpt-5.4"), "must not use the invented 'gpt-5.4' slug")
+        // Codex CLI uses gpt-5-codex; either that or another known-real slug
+        // (gpt-5, gpt-5-codex variants) is acceptable.
+        XCTAssertTrue(
+            model.hasPrefix("gpt-5") || model == "gpt-4o",
+            "default must be a known-real OpenAI model slug, got: \(model)"
+        )
+    }
+}


### PR DESCRIPTION
## Overview

Adds a new AI provider type — **OpenAI (Sign in)** — letting users authenticate
with their paid ChatGPT subscription instead of supplying an API key. Internally
this reuses the [Codex CLI](https://github.com/openai/codex) public OAuth client
to obtain Bearer tokens, then talks to `chatgpt.com/backend-api/codex/responses`
with SSE streaming.

For users who already pay for ChatGPT Plus / Pro / Team this avoids the
per-token API spend and the friction of generating + rotating an API key.

## Screenshots

### 1. New "OpenAI (Sign in)" entry in the provider type picker

<img width="588" height="671" alt="PixPin_2026-04-30_17-09-36" src="https://github.com/user-attachments/assets/c1c686d6-b950-412a-9925-abdaee3f85f9" />

### 2. Add Provider sheet — Authentication block before sign-in

<img width="560" height="540" alt="PixPin_2026-04-30_17-09-53" src="https://github.com/user-attachments/assets/4312f238-6f05-43f4-89e2-842cef906652" />

### 3. Edit Provider sheet — signed in, models loaded from `/backend-api/codex/models`

<img width="560" height="540" alt="PixPin_2026-04-30_17-10-53" src="https://github.com/user-attachments/assets/9c8dbb13-9235-4005-acd6-e5669106fd15" />

## How it works

1. User picks **OpenAI (Sign in)** in the Add Provider sheet.
2. Click **Sign in with OpenAI** → app opens the system browser at
   `auth.openai.com/authorize` with PKCE (RFC 7636) parameters.
3. After consent, OpenAI redirects to `http://localhost:1455/auth/callback` —
   a single-shot loopback HTTP listener inside the app accepts the redirect.
4. App exchanges the auth code for `access_token` / `refresh_token` /
   `id_token`, decodes the JWT for account metadata (email, plan), and stores
   the bundle in the macOS Keychain under `ai.chatgpt.tokens.<provider-uuid>`.
5. On every request, `ChatGPTOAuthService.tokenBundle(...)` checks `exp` and
   refreshes via `auth.openai.com/oauth/token` if within the skew window.
   Concurrent refreshes coalesce into a single `Task` to avoid token thrash.
6. `ChatGPTProvider` streams `/responses` SSE deltas. A 401/403 from either
   `/responses` or `/models` purges the keychain bundle and the UI reverts
   to the signed-out state.

## Architecture — 4 atomic commits

Split for bisect-friendliness; each commit compiles standalone.

1. **`feat(ai-core)`** — PKCE verifier/challenge, JWT payload decoder,
   `ChatGPTTokenBundle` value type. No outward dependencies.
2. **`feat(keychain)`** — `KeychainService` extension
   (`save/load/deleteChatGPTTokens`) keyed by provider UUID, plus unit tests
   for the primitives + Keychain round-trip.
3. **`feat(ai)`** — `ProviderType.chatGPT` enum case, loopback listener,
   OAuth service with refresh coalescing, `ChatGPTProvider`, factory /
   registry / DI wiring.
4. **`feat(settings)`** — `ProviderEditSheet` Sign-in / Sign-out UI,
   `AIChatView` send-button gating on token presence, `SettingsView`
   keychain cleanup on row removal.

## Risk / caveats

- **Not officially supported by OpenAI.** This reuses the Codex CLI's public
  OAuth client_id. If OpenAI rotates that client or changes the
  `/backend-api/codex/*` shape, the provider breaks until the constants in
  `ChatGPTOAuthConstants.swift` are updated.
- **Requires a paid ChatGPT plan.** Free-tier accounts cannot reach
  `/backend-api/codex/responses`.
- **macOS-only.** The loopback listener uses `Network.framework`;
  Windows/Linux ports would need their own implementation.
- **No long-lived API key.** Sign-out (manual or 401-triggered) deletes the
  Keychain bundle; users have to re-authenticate.

## Tests

- `ChatGPTOAuthTests.swift` — PKCE / JWT / token-bundle codec / Keychain
  round-trip
- `ChatGPTOAuthServiceTests.swift` — URL-protocol-mocked refresh path,
  concurrent-refresh coalescing, expired-token short-circuit,
  missing-keychain throw, SSE happy path + error event, `/models` filter +
  401 sign-out
- 28 / 28 passing locally (`swift test --filter ChatGPTOAuth`, ~0.5 s)

UI (sheet state machine, send-button gating) is covered by manual exploratory
testing — see test plan below. The codebase has no precedent for SwiftUI view
unit tests, so adding ViewInspector/XCUITest scaffolding solely for this PR
felt like over-engineering.

## Test plan

- [x] `swift test --filter ChatGPTOAuth` — 28 / 28 green
- [x] `swift build` — no new warnings
- [x] `./scripts/build-app.sh` — `Gridex.app` v0.0.14 builds, ~77 MB,
      ad-hoc signed
- [ ] Add Provider → pick "OpenAI (Sign in)" → Sign in → Save → AI chat works
- [ ] Add Provider → Sign in → Cancel sheet → Keychain bundle cleaned up
      (`security find-generic-password -s "Gridex" | grep ai.chatgpt.tokens`
      returns nothing)
- [ ] Edit existing ChatGPT row → Cancel sheet → bundle preserved
      (no rollback)
- [ ] Edit a row → switch type from API-key to ChatGPT → Sign in →
      Cancel → bundle cleaned up
- [ ] Sign out via UI → AIChatView send button greys out
- [ ] Force a 401 (revoke token elsewhere) → next message clears bundle,
      UI reverts to signed-out
- [ ] Remove provider row from Settings → both `ai.apikey.<uuid>` and
      `ai.chatgpt.tokens.<uuid>` purged
