### PR TITLE
feat(query): pgAdmin4-style EXPLAIN options dropdown

### DIFF
--- a/macos/Core/Extensions/DatabaseType+Explain.swift
+++ b/macos/Core/Extensions/DatabaseType+Explain.swift
@@ -11,14 +11,21 @@ import Foundation
 extension DatabaseType {
     /// Build the database-specific EXPLAIN SQL for `sql`. Returns nil when the
     /// engine has no SQL EXPLAIN (Mongo, Redis) or when `sql` is blank.
-    func explainSQL(for sql: String) -> String? {
+    ///
+    /// `options` shapes the PG `EXPLAIN (...)` option list. Other engines have
+    /// no per-option syntax, so the flags are ignored and we return their
+    /// plain `EXPLAIN` form.
+    ///
+    /// The default value preserves the previous hardcoded behaviour
+    /// (`EXPLAIN (ANALYZE false, COSTS true, FORMAT TEXT) ...`), so legacy
+    /// call sites stay byte-compatible.
+    func explainSQL(for sql: String, options: ExplainOptions = .default) -> String? {
         let trimmed = sql.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
         switch self {
         case .postgresql:
-            // ANALYZE=false → planner output without executing the query.
-            return "EXPLAIN (ANALYZE false, COSTS true, FORMAT TEXT) \(trimmed)"
+            return Self.buildPostgresExplain(sql: trimmed, options: options.sanitized())
         case .mysql:
             return "EXPLAIN \(trimmed)"
         case .sqlite:
@@ -31,5 +38,37 @@ extension DatabaseType {
         case .mongodb, .redis:
             return nil
         }
+    }
+
+    // MARK: - Postgres option-list builder
+
+    /// Produce `EXPLAIN (FOO true, BAR false, FORMAT JSON, ...) <sql>`.
+    /// ANALYZE / COSTS / FORMAT are always emitted (matches the legacy default
+    /// + makes the planner output reproducible regardless of server-side
+    /// defaults). Boolean toggles only appear when on. SERIALIZE only appears
+    /// when not `.off`.
+    private static func buildPostgresExplain(sql: String, options: ExplainOptions) -> String {
+        var parts: [String] = [
+            "ANALYZE \(options.analyze)",
+            "COSTS \(options.costs)",
+        ]
+
+        if options.buffers     { parts.append("BUFFERS true") }
+        if options.genericPlan { parts.append("GENERIC_PLAN true") }
+        if options.memory      { parts.append("MEMORY true") }
+        if options.settings    { parts.append("SETTINGS true") }
+        if options.summary     { parts.append("SUMMARY true") }
+        if options.timing      { parts.append("TIMING true") }
+        if options.verbose     { parts.append("VERBOSE true") }
+        if options.wal         { parts.append("WAL true") }
+
+        if options.serialize != .off {
+            parts.append("SERIALIZE \(options.serialize.rawValue)")
+        }
+
+        // FORMAT always last per PG convention (purely cosmetic; server doesn't care).
+        parts.append("FORMAT \(options.format.rawValue)")
+
+        return "EXPLAIN (\(parts.joined(separator: ", "))) \(sql)"
     }
 }

--- a/macos/Core/Models/Query/ExplainOptions.swift
+++ b/macos/Core/Models/Query/ExplainOptions.swift
@@ -1,0 +1,179 @@
+// ExplainOptions.swift
+// Gridex
+//
+// User-toggleable EXPLAIN options. Currently shaped for PostgreSQL — the only
+// engine with a rich option list (`EXPLAIN (FOO true, BAR false, ...)`).
+// MySQL / SQL Server / SQLite / ClickHouse have no per-option syntax, so the
+// builder ignores the flags for those engines and returns the engine's plain
+// `EXPLAIN` form.
+//
+// Cross-disable rules and version gating live here so the UI and the SQL
+// builder share a single source of truth — a future toolbar that doesn't
+// honour the rules can't accidentally produce a server-rejected query.
+
+import Foundation
+
+struct ExplainOptions: Equatable, Codable, Sendable {
+
+    // MARK: - PG flag toggles
+
+    /// Execute the query (modifies data!) and report actual times.
+    /// Off → planner output only, no side effects.
+    var analyze: Bool = false
+
+    /// Buffer-pool usage statistics.
+    /// PG 9.0+, before PG 13 only meaningful with ANALYZE.
+    var buffers: Bool = false
+
+    /// Show estimated planner costs. Default ON in PG.
+    var costs: Bool = true
+
+    /// Show plan for a prepared statement with generic parameter values.
+    /// PG 16+.
+    var genericPlan: Bool = false
+
+    /// Per-node memory usage during planning.
+    /// PG 17+.
+    var memory: Bool = false
+
+    /// Modified non-default GUC settings used to plan the query.
+    /// PG 12+.
+    var settings: Bool = false
+
+    /// Summary information (planning + execution time).
+    /// Default ON when ANALYZE is set.
+    var summary: Bool = false
+
+    /// Per-node actual time output.
+    /// Requires ANALYZE.
+    var timing: Bool = false
+
+    /// More-detailed per-node output (output columns, schema-qualified names).
+    var verbose: Bool = false
+
+    /// Per-node WAL usage.
+    /// PG 13+, requires ANALYZE.
+    var wal: Bool = false
+
+    // MARK: - Multi-value enums
+
+    enum Format: String, Codable, Sendable, CaseIterable, Identifiable {
+        case text = "TEXT"
+        case json = "JSON"
+        case yaml = "YAML"
+        case xml  = "XML"
+
+        var id: String { rawValue }
+        var displayName: String { rawValue.capitalized }
+    }
+
+    enum Serialize: String, Codable, Sendable, CaseIterable, Identifiable {
+        case off    = "OFF"     // do not include SERIALIZE in the option list
+        case none   = "NONE"
+        case text   = "TEXT"
+        case binary = "BINARY"
+
+        var id: String { rawValue }
+        var displayName: String {
+            self == .off ? "Off" : rawValue.capitalized
+        }
+    }
+
+    /// Output format. PG default is TEXT.
+    var format: Format = .text
+
+    /// SERIALIZE option (PG 17+, requires ANALYZE).
+    /// `.off` means don't include the option at all.
+    var serialize: Serialize = .off
+
+    // MARK: - Defaults
+
+    /// Matches the legacy hard-coded `EXPLAIN (ANALYZE false, COSTS true, FORMAT TEXT)`
+    /// — used when callers don't pass options.
+    static let `default` = ExplainOptions()
+}
+
+// MARK: - Cross-disable rules
+
+extension ExplainOptions {
+    /// PG enforces these constraints server-side; surfacing them in the model
+    /// lets the UI grey out impossible combinations before sending the query.
+
+    /// Options that are valid only when `analyze == true`.
+    /// Server rejects them with `EXPLAIN option X requires ANALYZE` otherwise.
+    enum AnalyzeDependency: CaseIterable {
+        case timing, wal, serialize
+    }
+
+    /// True when the toggle for `dep` should be enabled in the UI given the
+    /// current `analyze` setting.
+    func canEnable(_ dep: AnalyzeDependency) -> Bool {
+        analyze
+    }
+
+    /// Apply cross-disable rules — call before sending. Force-clears any
+    /// option that is invalid given the current settings.
+    func sanitized() -> ExplainOptions {
+        var copy = self
+        if !copy.analyze {
+            copy.timing = false
+            copy.wal = false
+            copy.serialize = .off
+        }
+        return copy
+    }
+}
+
+// MARK: - Version gating
+
+extension ExplainOptions {
+    /// Each option is keyed to the minimum PG major version on which it
+    /// becomes available. Older servers reject the option as a syntax error.
+    enum VersionGated: Hashable, CaseIterable {
+        case settings      // PG 12+
+        case wal           // PG 13+
+        case genericPlan   // PG 16+
+        case memory        // PG 17+
+        case serialize     // PG 17+
+
+        var minPostgresMajor: Int {
+            switch self {
+            case .settings:    return 12
+            case .wal:         return 13
+            case .genericPlan: return 16
+            case .memory:      return 17
+            case .serialize:   return 17
+            }
+        }
+
+        var displayName: String {
+            switch self {
+            case .settings:    return "Settings"
+            case .wal:         return "WAL"
+            case .genericPlan: return "Generic Plan"
+            case .memory:      return "Memory"
+            case .serialize:   return "Serialize"
+            }
+        }
+    }
+
+    /// True when option is supported on a PG server reporting major version
+    /// `serverMajor`. Pass nil when the version is unknown — we permit the
+    /// option in that case and let the server tell the user (consistent with
+    /// the rest of the codebase, which doesn't pre-detect server features).
+    static func isAvailable(_ option: VersionGated, on serverMajor: Int?) -> Bool {
+        guard let v = serverMajor else { return true }
+        return v >= option.minPostgresMajor
+    }
+}
+
+// MARK: - Persistence keying
+
+extension ExplainOptions {
+    /// UserDefaults key for storing the last-used options per connection.
+    /// Connection-scoped so a user's PG 17 server can keep Memory enabled
+    /// without polluting a sibling PG 12 connection.
+    static func userDefaultsKey(connectionId: UUID) -> String {
+        "explainOptions.\(connectionId.uuidString)"
+    }
+}

--- a/macos/Core/Models/Query/ExplainOptions.swift
+++ b/macos/Core/Models/Query/ExplainOptions.swift
@@ -91,6 +91,26 @@ struct ExplainOptions: Equatable, Codable, Sendable {
     /// Matches the legacy hard-coded `EXPLAIN (ANALYZE false, COSTS true, FORMAT TEXT)`
     /// — used when callers don't pass options.
     static let `default` = ExplainOptions()
+
+    /// "Profile" preset — what a senior dev would tick before debugging a slow
+    /// SELECT: actual times, buffer hits/reads, schema-qualified output, plus
+    /// the planning/execution summary. Does NOT change FORMAT — caller keeps
+    /// whatever they already set so JSON-tree users don't get downgraded to
+    /// TEXT after applying the preset.
+    ///
+    /// **Caution**: enabling ANALYZE means the query is actually executed.
+    /// Safe for SELECT, dangerous for INSERT/UPDATE/DELETE (will modify data).
+    /// The UI surfaces this preset as "Profile (SELECT)" to make the
+    /// expectation explicit.
+    static func profilePreset(currentFormat: Format) -> ExplainOptions {
+        var opts = ExplainOptions.default
+        opts.analyze = true
+        opts.buffers = true
+        opts.verbose = true
+        opts.summary = true
+        opts.format  = currentFormat
+        return opts
+    }
 }
 
 // MARK: - Cross-disable rules

--- a/macos/Presentation/Views/QueryEditor/Explain/ExplainOptionsMenu.swift
+++ b/macos/Presentation/Views/QueryEditor/Explain/ExplainOptionsMenu.swift
@@ -1,0 +1,100 @@
+// ExplainOptionsMenu.swift
+// Gridex
+//
+// pgAdmin4-style dropdown attached to the Explain button. Surfaces every PG
+// EXPLAIN option as a toggle, with cross-disable + version gating already
+// enforced in the model (`ExplainOptions.canEnable` / `isAvailable`).
+//
+// Visible only for PostgreSQL connections — the other engines have no
+// option list. The dropdown vanishes for them; the plain Explain button
+// remains.
+
+import SwiftUI
+
+struct ExplainOptionsMenu: View {
+    @Binding var options: ExplainOptions
+
+    /// PG server major version, when known (`SHOW server_version_num` / 10000).
+    /// Pass nil to permit every option (server will reject if it can't handle).
+    let serverMajorVersion: Int?
+
+    var body: some View {
+        Menu {
+            // ANALYZE — toggle prominently at the top. It's the load-bearing
+            // setting (off = plan only / safe; on = execute query / measure).
+            Toggle("Analyze (execute query)", isOn: $options.analyze)
+
+            Divider()
+
+            // Plain bool options, alphabetised after Analyze for predictability.
+            Toggle("Buffers", isOn: $options.buffers)
+            Toggle("Costs",   isOn: $options.costs)
+            versionGatedToggle("Generic Plan", $options.genericPlan, gate: .genericPlan)
+            versionGatedToggle("Memory",       $options.memory,      gate: .memory)
+            Toggle("Settings", isOn: $options.settings)
+                .disabled(!ExplainOptions.isAvailable(.settings, on: serverMajorVersion))
+            Toggle("Summary", isOn: $options.summary)
+            Toggle("Timing",  isOn: $options.timing)
+                .disabled(!options.canEnable(.timing))
+            Toggle("Verbose", isOn: $options.verbose)
+            Toggle("WAL", isOn: $options.wal)
+                .disabled(!options.canEnable(.wal) || !ExplainOptions.isAvailable(.wal, on: serverMajorVersion))
+
+            Divider()
+
+            // Serialize — submenu like pgAdmin4. Off-state renders as a plain
+            // disabled item; the values appear when ANALYZE is on.
+            Menu("Serialize") {
+                ForEach(ExplainOptions.Serialize.allCases) { value in
+                    Button {
+                        options.serialize = value
+                    } label: {
+                        if options.serialize == value {
+                            Label(value.displayName, systemImage: "checkmark")
+                        } else {
+                            Text(value.displayName)
+                        }
+                    }
+                }
+            }
+            .disabled(!options.canEnable(.serialize) || !ExplainOptions.isAvailable(.serialize, on: serverMajorVersion))
+
+            // Format — submenu. JSON unlocks visual-tree rendering downstream.
+            Menu("Format") {
+                ForEach(ExplainOptions.Format.allCases) { value in
+                    Button {
+                        options.format = value
+                    } label: {
+                        if options.format == value {
+                            Label(value.displayName, systemImage: "checkmark")
+                        } else {
+                            Text(value.displayName)
+                        }
+                    }
+                }
+            }
+        } label: {
+            // Just a chevron next to the Explain button — caller draws the
+            // primary "Explain" button itself, this is the disclosure.
+            Image(systemName: "chevron.down")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .controlSize(.small)
+        .fixedSize()
+        .help("EXPLAIN options")
+    }
+
+    @ViewBuilder
+    private func versionGatedToggle(
+        _ title: String,
+        _ binding: Binding<Bool>,
+        gate: ExplainOptions.VersionGated
+    ) -> some View {
+        let available = ExplainOptions.isAvailable(gate, on: serverMajorVersion)
+        Toggle(available ? title : "\(title) (PG \(gate.minPostgresMajor)+)", isOn: binding)
+            .disabled(!available)
+    }
+}

--- a/macos/Presentation/Views/QueryEditor/Explain/ExplainOptionsMenu.swift
+++ b/macos/Presentation/Views/QueryEditor/Explain/ExplainOptionsMenu.swift
@@ -20,6 +20,17 @@ struct ExplainOptionsMenu: View {
 
     var body: some View {
         Menu {
+            // Quick preset — sets the four options a senior dev would tick
+            // before debugging a slow SELECT (Analyze, Buffers, Verbose,
+            // Summary). Keeps current Format so users on Tree view don't get
+            // bumped back to Text. The "(SELECT)" suffix is a load-bearing
+            // hint that this turns on ANALYZE → query is actually executed.
+            Button("Apply ‘Profile’ preset (SELECT)") {
+                options = ExplainOptions.profilePreset(currentFormat: options.format)
+            }
+
+            Divider()
+
             // ANALYZE — toggle prominently at the top. It's the load-bearing
             // setting (off = plan only / safe; on = execute query / measure).
             Toggle("Analyze (execute query)", isOn: $options.analyze)

--- a/macos/Presentation/Views/QueryEditor/Explain/ExplainOutputView.swift
+++ b/macos/Presentation/Views/QueryEditor/Explain/ExplainOutputView.swift
@@ -1,0 +1,428 @@
+// ExplainOutputView.swift
+// Gridex
+//
+// Three view-modes over a single EXPLAIN output string:
+//   • Text — server output verbatim, monospace, optional word wrap
+//   • JSON — JSONSerialization-prettified + lightweight syntax highlight
+//   • Tree — recursive DisclosureGroup walk of the JSON plan
+//
+// Read-only browser only. No heat coloring, no slow-node detection, no
+// recommendations. The richer "Analysis tab with timing heatmap +
+// recommendations" view lives in the Enterprise Edition's
+// EEExplainVisualizerView; this OSS surface intentionally stops short.
+
+import SwiftUI
+
+enum ExplainViewMode: String, CaseIterable, Identifiable {
+    case text, json, tree
+
+    var id: String { rawValue }
+    var displayName: String {
+        switch self {
+        case .text: return "Text"
+        case .json: return "JSON"
+        case .tree: return "Tree"
+        }
+    }
+    var systemImage: String {
+        switch self {
+        case .text: return "text.alignleft"
+        case .json: return "curlybraces"
+        case .tree: return "list.bullet.indent"
+        }
+    }
+}
+
+struct ExplainOutputView: View {
+
+    /// Raw output as returned by the server. For PG `FORMAT TEXT` this is the
+    /// concatenated `QUERY PLAN` rows; for `FORMAT JSON` it's the entire JSON
+    /// document the server emits in the first row's first cell.
+    let raw: String
+
+    /// What format the user asked for. Used to pick the initial view mode and
+    /// to gate the Tree view (only meaningful for JSON/YAML output).
+    let format: ExplainOptions.Format
+
+    @State private var mode: ExplainViewMode
+    @State private var wordWrap: Bool = true
+
+    init(raw: String, format: ExplainOptions.Format) {
+        self.raw = raw
+        self.format = format
+        // Auto-pick: if the user asked for JSON, default to Tree (most useful).
+        // Otherwise default to Text.
+        let initial: ExplainViewMode = (format == .json) ? .tree : .text
+        _mode = State(initialValue: initial)
+    }
+
+    /// View modes available for the current output. Non-JSON plans can't be
+    /// browsed as a tree — hide the Tree segment in that case so the picker
+    /// doesn't show a non-functional option.
+    private var availableModes: [ExplainViewMode] {
+        format == .json ? ExplainViewMode.allCases : [.text]
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            // View-mode picker. Single-segment for non-JSON output (no choice
+            // to make), full picker when JSON.
+            if availableModes.count > 1 {
+                Picker("", selection: $mode) {
+                    ForEach(availableModes) { m in
+                        Label(m.displayName, systemImage: m.systemImage).tag(m)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .fixedSize()
+            } else {
+                Label("Text", systemImage: ExplainViewMode.text.systemImage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if mode == .text || mode == .json {
+                Toggle(isOn: $wordWrap) {
+                    Label("Wrap", systemImage: "arrow.turn.down.left")
+                        .labelStyle(.iconOnly)
+                }
+                .toggleStyle(.button)
+                .controlSize(.small)
+                .help("Word wrap")
+            }
+
+            Button {
+                copyToPasteboard()
+            } label: {
+                Label("Copy", systemImage: "doc.on.doc")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .help("Copy raw output")
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    // MARK: - Body
+
+    @ViewBuilder
+    private var content: some View {
+        switch mode {
+        case .text: textView
+        case .json: jsonView
+        case .tree: treeView
+        }
+    }
+
+    // MARK: - Text mode
+
+    private var textView: some View {
+        ScrollView([.vertical, wordWrap ? [] : .horizontal]) {
+            Text(raw)
+                .font(.system(size: 12, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: wordWrap ? .infinity : nil, alignment: .leading)
+                .padding(8)
+        }
+    }
+
+    // MARK: - JSON mode
+
+    private var jsonView: some View {
+        let pretty = ExplainJSONPrettyPrinter.prettyPrint(raw) ?? raw
+        return ScrollView([.vertical, wordWrap ? [] : .horizontal]) {
+            ExplainJSONHighlightedText(text: pretty)
+                .font(.system(size: 12, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: wordWrap ? .infinity : nil, alignment: .leading)
+                .padding(8)
+        }
+    }
+
+    // MARK: - Tree mode
+
+    @ViewBuilder
+    private var treeView: some View {
+        if let nodes = ExplainPlanReader.parse(jsonString: raw), !nodes.isEmpty {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(nodes) { node in
+                        ExplainPlanNodeRow(node: node, depth: 0)
+                    }
+                }
+                .padding(8)
+            }
+        } else {
+            Text("Tree view requires `FORMAT JSON` output.\nSwitch the EXPLAIN format to JSON and re-run.")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func copyToPasteboard() {
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(raw, forType: .string)
+    }
+}
+
+// MARK: - JSON pretty printer
+
+enum ExplainJSONPrettyPrinter {
+    /// Re-encode the JSON with `.prettyPrinted + .sortedKeys` for stable output.
+    /// Returns nil when `raw` isn't valid JSON — caller falls back to the raw
+    /// string so the user sees something instead of a blank panel.
+    static func prettyPrint(_ raw: String) -> String? {
+        guard let data = raw.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]),
+              let pretty = try? JSONSerialization.data(
+                  withJSONObject: obj,
+                  options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+              ),
+              let string = String(data: pretty, encoding: .utf8)
+        else { return nil }
+        return string
+    }
+}
+
+// MARK: - Lightweight JSON syntax highlight
+
+/// Tokenises JSON text and emits each token as a coloured `Text` segment.
+/// Single-pass O(n), no parser — just lexical: strings (red-ish), numbers
+/// (green-ish), keywords (purple), keys (blue, when followed by `:`).
+struct ExplainJSONHighlightedText: View {
+    let text: String
+
+    var body: some View {
+        // SwiftUI can concat Text segments via `+`. Build incrementally.
+        var result = Text("")
+        for token in tokenise(text) {
+            result = result + Text(token.lexeme)
+                .foregroundColor(token.kind.color)
+        }
+        return result.lineLimit(nil)
+    }
+
+    private struct Token {
+        let lexeme: String
+        let kind: Kind
+        enum Kind {
+            case key, string, number, keyword, punctuation, whitespace, other
+            var color: Color {
+                switch self {
+                case .key:         return Color.blue
+                case .string:      return Color(nsColor: .systemRed)
+                case .number:      return Color(nsColor: .systemGreen)
+                case .keyword:     return Color(nsColor: .systemPurple)
+                case .punctuation: return Color.secondary
+                case .whitespace:  return Color.primary
+                case .other:       return Color.primary
+                }
+            }
+        }
+    }
+
+    /// Naïve lexer: enough to colour the canonical Postgres EXPLAIN JSON output.
+    /// Doesn't try to be a full RFC 8259 parser — fragments + valid JSON both work.
+    private func tokenise(_ s: String) -> [Token] {
+        var tokens: [Token] = []
+        var i = s.startIndex
+
+        while i < s.endIndex {
+            let c = s[i]
+            if c.isWhitespace || c.isNewline {
+                let start = i
+                while i < s.endIndex && (s[i].isWhitespace || s[i].isNewline) { i = s.index(after: i) }
+                tokens.append(Token(lexeme: String(s[start..<i]), kind: .whitespace))
+            } else if c == "\"" {
+                // Read a string literal. Look ahead to decide if it's a key
+                // (followed by `:` after optional whitespace).
+                let start = i
+                i = s.index(after: i)
+                while i < s.endIndex && s[i] != "\"" {
+                    if s[i] == "\\" && s.index(after: i) < s.endIndex {
+                        i = s.index(after: i) // skip escaped char
+                    }
+                    i = s.index(after: i)
+                }
+                if i < s.endIndex { i = s.index(after: i) }
+                let literal = String(s[start..<i])
+
+                // Peek for `:` to detect "key" role.
+                var j = i
+                while j < s.endIndex && s[j].isWhitespace { j = s.index(after: j) }
+                let isKey = j < s.endIndex && s[j] == ":"
+                tokens.append(Token(lexeme: literal, kind: isKey ? .key : .string))
+            } else if c.isNumber || c == "-" {
+                let start = i
+                if c == "-" { i = s.index(after: i) }
+                while i < s.endIndex && (s[i].isNumber || s[i] == "." || s[i] == "e" || s[i] == "E" || s[i] == "+" || s[i] == "-") {
+                    i = s.index(after: i)
+                }
+                tokens.append(Token(lexeme: String(s[start..<i]), kind: .number))
+            } else if c.isLetter {
+                let start = i
+                while i < s.endIndex && s[i].isLetter { i = s.index(after: i) }
+                let word = String(s[start..<i])
+                let kind: Token.Kind = (word == "true" || word == "false" || word == "null") ? .keyword : .other
+                tokens.append(Token(lexeme: word, kind: kind))
+            } else if "{}[],:".contains(c) {
+                tokens.append(Token(lexeme: String(c), kind: .punctuation))
+                i = s.index(after: i)
+            } else {
+                tokens.append(Token(lexeme: String(c), kind: .other))
+                i = s.index(after: i)
+            }
+        }
+        return tokens
+    }
+}
+
+// MARK: - Tree mode plumbing
+
+/// Lightweight read-only walker over the Postgres `EXPLAIN (FORMAT JSON)`
+/// output shape. NOT a plan analysis engine — that's an Enterprise Edition
+/// feature. This keeps just enough structure to render a DisclosureGroup
+/// tree of node names + cost summary lines.
+struct ExplainPlanNode: Identifiable {
+    let id = UUID()
+    let nodeType: String
+    let summary: String          // "(cost=… rows=… loops=…)"
+    let attributes: [(String, String)]  // remaining flat key/value pairs for an inspector row
+    let children: [ExplainPlanNode]
+}
+
+enum ExplainPlanReader {
+    /// Parse `EXPLAIN (FORMAT JSON)` text into a flat array of root nodes
+    /// (PG returns one root per statement). Returns nil when the input
+    /// isn't a JSON array or doesn't have the expected `Plan` shape.
+    static func parse(jsonString: String) -> [ExplainPlanNode]? {
+        guard let data = jsonString.data(using: .utf8),
+              let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return nil }
+
+        let nodes = arr.compactMap { obj -> ExplainPlanNode? in
+            guard let plan = obj["Plan"] as? [String: Any] else { return nil }
+            return makeNode(plan)
+        }
+        return nodes.isEmpty ? nil : nodes
+    }
+
+    private static func makeNode(_ plan: [String: Any]) -> ExplainPlanNode {
+        let nodeType = plan["Node Type"] as? String ?? "(unknown)"
+
+        // Summary line — the same shape PG emits in FORMAT TEXT.
+        var summaryParts: [String] = []
+        if let startup = plan["Startup Cost"] as? Double, let total = plan["Total Cost"] as? Double {
+            summaryParts.append(String(format: "cost=%.2f..%.2f", startup, total))
+        } else if let total = plan["Total Cost"] as? Double {
+            summaryParts.append(String(format: "cost=%.2f", total))
+        }
+        if let rows = plan["Plan Rows"] as? Int { summaryParts.append("rows=\(rows)") }
+        if let width = plan["Plan Width"] as? Int { summaryParts.append("width=\(width)") }
+
+        // Pull every other primitive key into the attributes list so the user
+        // can browse them under a node row without us interpreting anything.
+        var attributes: [(String, String)] = []
+        let exclude: Set<String> = [
+            "Plans", "Node Type",
+            "Startup Cost", "Total Cost", "Plan Rows", "Plan Width",
+        ]
+        for key in plan.keys.sorted() where !exclude.contains(key) {
+            let value = plan[key]
+            if let str = value as? String {
+                attributes.append((key, str))
+            } else if let num = value as? NSNumber {
+                // JSONSerialization wraps both numbers and booleans in NSNumber.
+                // CFBoolean type check is the reliable way to tell them apart;
+                // a plain `as? Bool` would mis-classify 0/1 as false/true.
+                if CFGetTypeID(num) == CFBooleanGetTypeID() {
+                    attributes.append((key, num.boolValue ? "true" : "false"))
+                } else {
+                    attributes.append((key, num.stringValue))
+                }
+            }
+            // Arrays/objects are skipped — we don't try to render them inline.
+        }
+
+        let childPlans = plan["Plans"] as? [[String: Any]] ?? []
+        let children = childPlans.map(makeNode)
+
+        return ExplainPlanNode(
+            nodeType: nodeType,
+            summary: summaryParts.joined(separator: " "),
+            attributes: attributes,
+            children: children
+        )
+    }
+}
+
+// MARK: - Tree row
+
+/// One DisclosureGroup per node, recursively. Read-only — clicking a node
+/// just expands/collapses; clicking an attribute does nothing. No timing
+/// heat colors and no recommendation cards (those belong in EE).
+struct ExplainPlanNodeRow: View {
+    let node: ExplainPlanNode
+    let depth: Int
+
+    @State private var expanded: Bool = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            DisclosureGroup(isExpanded: $expanded) {
+                VStack(alignment: .leading, spacing: 2) {
+                    if !node.attributes.isEmpty {
+                        ForEach(node.attributes, id: \.0) { (k, v) in
+                            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                                Text(k)
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .foregroundStyle(.secondary)
+                                Text(v)
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .textSelection(.enabled)
+                            }
+                            .padding(.leading, 16)
+                        }
+                    }
+                    ForEach(node.children) { child in
+                        ExplainPlanNodeRow(node: child, depth: depth + 1)
+                    }
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "chevron.right.circle.fill")
+                        .foregroundStyle(.tint)
+                        .font(.system(size: 11))
+                    Text(node.nodeType)
+                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    if !node.summary.isEmpty {
+                        Text(node.summary)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/macos/Presentation/Views/QueryEditor/Explain/ExplainOutputView.swift
+++ b/macos/Presentation/Views/QueryEditor/Explain/ExplainOutputView.swift
@@ -44,12 +44,19 @@ struct ExplainOutputView: View {
     /// to gate the Tree view (only meaningful for JSON/YAML output).
     let format: ExplainOptions.Format
 
+    /// Whether the EXPLAIN was run with ANALYZE on. Drives the inline hint
+    /// banner below — without ANALYZE the user only sees plan estimates, not
+    /// actual times / row counts / buffer stats, which is rarely enough to
+    /// debug a real performance issue.
+    let analyzed: Bool
+
     @State private var mode: ExplainViewMode
     @State private var wordWrap: Bool = true
 
-    init(raw: String, format: ExplainOptions.Format) {
+    init(raw: String, format: ExplainOptions.Format, analyzed: Bool) {
         self.raw = raw
         self.format = format
+        self.analyzed = analyzed
         // Auto-pick: if the user asked for JSON, default to Tree (most useful).
         // Otherwise default to Text.
         let initial: ExplainViewMode = (format == .json) ? .tree : .text
@@ -67,8 +74,30 @@ struct ExplainOutputView: View {
         VStack(spacing: 0) {
             header
             Divider()
+            if !analyzed {
+                analyzeHint
+                Divider()
+            }
             content
         }
+    }
+
+    /// Inline tip surfaced when ANALYZE is off. Most user-facing perf debug
+    /// requires actual times / row counts / cache stats — this nudges the
+    /// user toward the right toggles without forcing them.
+    private var analyzeHint: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Image(systemName: "lightbulb")
+                .font(.system(size: 11))
+                .foregroundStyle(.yellow)
+            Text("Tip: enable **Analyze** + **Buffers** in the options menu to see actual times and cache stats. The current output is plan estimates only.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
     }
 
     // MARK: - Header

--- a/macos/Presentation/Views/QueryEditor/QueryEditorView.swift
+++ b/macos/Presentation/Views/QueryEditor/QueryEditorView.swift
@@ -28,6 +28,12 @@ struct QueryEditorView: View {
     /// grey out options the server doesn't support (Memory needs PG 17+, etc.)
     @State private var pgServerMajorVersion: Int?
 
+    /// Raw EXPLAIN output (text or JSON, depending on `explainOutputFormat`).
+    /// Non-nil means the results pane should render the read-only Explain
+    /// browser instead of the data grid. Cleared by every regular Run.
+    @State private var explainOutput: String?
+    @State private var explainOutputFormat: ExplainOptions.Format = .text
+
     private var isRedis: Bool { appState.activeConfig?.databaseType == .redis }
     private var isPostgres: Bool { appState.activeConfig?.databaseType == .postgresql }
 
@@ -155,6 +161,8 @@ struct QueryEditorView: View {
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding()
+                } else if let output = explainOutput {
+                    ExplainOutputView(raw: output, format: explainOutputFormat)
                 } else if !resultViewModel.columns.isEmpty {
                     AppKitDataGrid(
                         viewModel: resultViewModel,
@@ -220,6 +228,10 @@ struct QueryEditorView: View {
 
     private func executeQuery() {
         guard let adapter = appState.activeAdapter else { return }
+
+        // A regular Run wipes any previous EXPLAIN output so the data grid
+        // can take over the results pane again.
+        explainOutput = nil
 
         // Decide: run a single statement at cursor, or a full multi-statement script.
         // Heuristic: if the text contains `GO` batch separators (SQL Server) or
@@ -422,12 +434,25 @@ struct QueryEditorView: View {
                 let duration = Date().timeIntervalSince(start)
                 appState.logQuery(sql: explainSQL, duration: duration)
                 appState.recordQueryHistory(sql: explainSQL, duration: duration, rowCount: result.rowCount)
-                applyResult(result)
+
+                // PG returns the plan as one row per text line (FORMAT TEXT)
+                // or one row containing the whole document (FORMAT JSON).
+                // Either way, joining the first cell of every row yields the
+                // raw output we hand to ExplainOutputView.
+                let raw = result.rows
+                    .compactMap { $0.first?.stringValue }
+                    .joined(separator: "\n")
+                explainOutput = raw
+                explainOutputFormat = isPostgres ? optsForBuild.format : .text
+                resultViewModel.columns = []  // hide grid; show explain panel
+                resultViewModel.rows = []
+                resultRowCount = 0
             } catch {
                 let duration = Date().timeIntervalSince(start)
                 appState.logQuery(sql: explainSQL, duration: duration)
                 appState.recordQueryHistory(sql: explainSQL, duration: duration, error: error.localizedDescription)
                 errorMessage = error.localizedDescription
+                explainOutput = nil
             }
             isExecuting = false
         }

--- a/macos/Presentation/Views/QueryEditor/QueryEditorView.swift
+++ b/macos/Presentation/Views/QueryEditor/QueryEditorView.swift
@@ -19,7 +19,17 @@ struct QueryEditorView: View {
     @State private var isExecuting = false
     @State private var splitRatio: CGFloat = 0.5
 
+    /// EXPLAIN options surfaced in the dropdown next to the Explain button.
+    /// Persisted per-connection via UserDefaults so a fix applied in one
+    /// session sticks across restarts.
+    @State private var explainOptions: ExplainOptions = .default
+
+    /// PG server major version (`SHOW server_version_num` / 10000), used to
+    /// grey out options the server doesn't support (Memory needs PG 17+, etc.)
+    @State private var pgServerMajorVersion: Int?
+
     private var isRedis: Bool { appState.activeConfig?.databaseType == .redis }
+    private var isPostgres: Bool { appState.activeConfig?.databaseType == .postgresql }
 
     var body: some View {
         VSplitView {
@@ -69,14 +79,28 @@ struct QueryEditorView: View {
                     .help(isRedis ? "Run Redis command (⌘R)" : "Run statement at cursor (⌘R)")
 
                     if !isRedis {
-                        Button(action: explainQuery) {
-                            HStack(spacing: 4) {
-                                Image(systemName: "lightbulb")
-                                Text("Explain")
+                        // Split: primary button runs EXPLAIN with the current
+                        // options; the chevron beside opens the toggle menu.
+                        // For non-PG engines the menu is hidden — they have
+                        // no per-option syntax to surface.
+                        HStack(spacing: 0) {
+                            Button(action: explainQuery) {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "lightbulb")
+                                    Text("Explain")
+                                }
+                            }
+                            .controlSize(.small)
+                            .pointerCursor()
+
+                            if isPostgres {
+                                ExplainOptionsMenu(
+                                    options: $explainOptions,
+                                    serverMajorVersion: pgServerMajorVersion
+                                )
+                                .padding(.leading, 2)
                             }
                         }
-                        .controlSize(.small)
-                        .pointerCursor()
                     }
                 }
                 .padding(.horizontal, 8)
@@ -155,10 +179,14 @@ struct QueryEditorView: View {
             if let saved = appState.queryEditorText[tabId] {
                 sqlText = saved
             }
+            loadExplainOptionsForActiveConnection()
         }
         .onChange(of: sqlText) { _, newValue in
             // Persist so tab switches don't lose the query
             appState.queryEditorText[tabId] = newValue
+        }
+        .onChange(of: appState.activeConnectionId) { _, _ in
+            loadExplainOptionsForActiveConnection()
         }
         .onReceive(NotificationCenter.default.publisher(for: .init("pasteQueryToEditor"))) { notif in
             // Only the currently active query editor tab handles the paste
@@ -374,11 +402,19 @@ struct QueryEditorView: View {
         isExecuting = true
         errorMessage = nil
 
-        guard let explainSQL = adapter.databaseType.explainSQL(for: sql) else {
+        // Options apply only to PG (other engines ignore the param).
+        let optsForBuild = isPostgres ? explainOptions : .default
+        guard let explainSQL = adapter.databaseType.explainSQL(for: sql, options: optsForBuild) else {
             errorMessage = "EXPLAIN is not supported for \(adapter.databaseType.displayName) connections."
             isExecuting = false
             return
         }
+
+        // Persist whatever the user just used so the next session restores it.
+        if isPostgres, let connId = appState.activeConnectionId {
+            persistExplainOptions(explainOptions, for: connId)
+        }
+
         Task {
             let start = Date()
             do {
@@ -395,6 +431,53 @@ struct QueryEditorView: View {
             }
             isExecuting = false
         }
+    }
+
+    // MARK: - EXPLAIN options persistence + version detection
+
+    /// Load saved options for the active connection (and probe server version
+    /// for PG, so the menu can grey-out unavailable options).
+    private func loadExplainOptionsForActiveConnection() {
+        guard let connId = appState.activeConnectionId else {
+            explainOptions = .default
+            pgServerMajorVersion = nil
+            return
+        }
+        let key = ExplainOptions.userDefaultsKey(connectionId: connId)
+        if let data = UserDefaults.standard.data(forKey: key),
+           let saved = try? JSONDecoder().decode(ExplainOptions.self, from: data) {
+            explainOptions = saved
+        } else {
+            explainOptions = .default
+        }
+
+        guard isPostgres, let adapter = appState.activeAdapter else {
+            pgServerMajorVersion = nil
+            return
+        }
+        Task {
+            // `serverVersion()` returns the long banner; extract the major.
+            // Failure → leave nil → menu permits everything (server enforces).
+            let version = (try? await adapter.serverVersion()) ?? ""
+            await MainActor.run {
+                pgServerMajorVersion = Self.parsePostgresMajor(from: version)
+            }
+        }
+    }
+
+    private func persistExplainOptions(_ opts: ExplainOptions, for connId: UUID) {
+        guard let data = try? JSONEncoder().encode(opts) else { return }
+        UserDefaults.standard.set(data, forKey: ExplainOptions.userDefaultsKey(connectionId: connId))
+    }
+
+    /// Pull the major from the `version()` banner.
+    /// Examples: "PostgreSQL 16.2 on …" → 16; "PostgreSQL 9.6.24 …" → 9.
+    static func parsePostgresMajor(from banner: String) -> Int? {
+        // Look for the first integer after "PostgreSQL ".
+        guard let range = banner.range(of: "PostgreSQL ") else { return nil }
+        let tail = banner[range.upperBound...]
+        let digits = tail.prefix { $0.isNumber }
+        return Int(digits)
     }
 
     /// Populate the DataGridViewState with query results so AppKitDataGrid can render them

--- a/macos/Presentation/Views/QueryEditor/QueryEditorView.swift
+++ b/macos/Presentation/Views/QueryEditor/QueryEditorView.swift
@@ -33,6 +33,7 @@ struct QueryEditorView: View {
     /// browser instead of the data grid. Cleared by every regular Run.
     @State private var explainOutput: String?
     @State private var explainOutputFormat: ExplainOptions.Format = .text
+    @State private var explainOutputAnalyzed: Bool = false
 
     private var isRedis: Bool { appState.activeConfig?.databaseType == .redis }
     private var isPostgres: Bool { appState.activeConfig?.databaseType == .postgresql }
@@ -162,7 +163,11 @@ struct QueryEditorView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding()
                 } else if let output = explainOutput {
-                    ExplainOutputView(raw: output, format: explainOutputFormat)
+                    ExplainOutputView(
+                        raw: output,
+                        format: explainOutputFormat,
+                        analyzed: explainOutputAnalyzed
+                    )
                 } else if !resultViewModel.columns.isEmpty {
                     AppKitDataGrid(
                         viewModel: resultViewModel,
@@ -444,6 +449,7 @@ struct QueryEditorView: View {
                     .joined(separator: "\n")
                 explainOutput = raw
                 explainOutputFormat = isPostgres ? optsForBuild.format : .text
+                explainOutputAnalyzed = isPostgres ? optsForBuild.analyze : false
                 resultViewModel.columns = []  // hide grid; show explain panel
                 resultViewModel.rows = []
                 resultRowCount = 0

--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -32,9 +32,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.15</string>
+	<string>0.0.16</string>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>16</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAppTransportSecurity</key>

--- a/macos/Tests/GridexTests/ExplainOptionsTests.swift
+++ b/macos/Tests/GridexTests/ExplainOptionsTests.swift
@@ -1,0 +1,213 @@
+// ExplainOptionsTests.swift
+// Pure-logic tests for the new ExplainOptions struct + the PG `EXPLAIN (...)`
+// option-list builder it powers. No infra needed.
+
+import XCTest
+@testable import Gridex
+
+final class ExplainOptionsTests: XCTestCase {
+
+    private let sql = "SELECT * FROM profile"
+
+    // MARK: - Default value pins legacy behaviour
+
+    func test_default_buildsLegacyShape() {
+        // The previous hardcoded query was
+        //   "EXPLAIN (ANALYZE false, COSTS true, FORMAT TEXT) <sql>"
+        // The default value of ExplainOptions must reproduce it exactly so
+        // every existing call site stays byte-compatible.
+        let out = DatabaseType.postgresql.explainSQL(for: sql)
+        XCTAssertEqual(out, "EXPLAIN (ANALYZE false, COSTS true, FORMAT TEXT) \(sql)")
+    }
+
+    // MARK: - Always-emitted vs opt-in toggles
+
+    func test_costsCanBeTurnedOff() {
+        var opts = ExplainOptions.default
+        opts.costs = false
+        let out = DatabaseType.postgresql.explainSQL(for: sql, options: opts)
+        XCTAssertEqual(out, "EXPLAIN (ANALYZE false, COSTS false, FORMAT TEXT) \(sql)")
+    }
+
+    func test_offToggles_doNotAppearInOutput() {
+        // Buffers / Memory / Settings / Summary / Verbose / WAL all default
+        // false, must not bloat the option list.
+        let out = DatabaseType.postgresql.explainSQL(for: sql)!
+        XCTAssertFalse(out.contains("BUFFERS"))
+        XCTAssertFalse(out.contains("MEMORY"))
+        XCTAssertFalse(out.contains("SETTINGS"))
+        XCTAssertFalse(out.contains("SUMMARY"))
+        XCTAssertFalse(out.contains("VERBOSE"))
+        XCTAssertFalse(out.contains("WAL"))
+        XCTAssertFalse(out.contains("GENERIC_PLAN"))
+        XCTAssertFalse(out.contains("SERIALIZE"))
+    }
+
+    func test_onToggles_appearWithTrue() {
+        var opts = ExplainOptions.default
+        opts.buffers     = true
+        opts.memory      = true
+        opts.settings    = true
+        opts.summary     = true
+        opts.verbose     = true
+        let out = DatabaseType.postgresql.explainSQL(for: sql, options: opts)!
+        for piece in ["BUFFERS true", "MEMORY true", "SETTINGS true",
+                      "SUMMARY true", "VERBOSE true"] {
+            XCTAssertTrue(out.contains(piece), "missing '\(piece)' in: \(out)")
+        }
+    }
+
+    // MARK: - Cross-disable: ANALYZE-dependent options
+
+    func test_timing_requiresAnalyze_sanitizedOut() {
+        // User toggles Timing on without enabling Analyze. PG would 400 with
+        // "EXPLAIN option TIMING requires ANALYZE". `sanitized()` (called
+        // inside the builder) drops the offending flag pre-flight.
+        var opts = ExplainOptions.default
+        opts.analyze = false
+        opts.timing = true
+        let out = DatabaseType.postgresql.explainSQL(for: sql, options: opts)!
+        XCTAssertFalse(out.contains("TIMING"), "TIMING must be stripped when ANALYZE is off")
+    }
+
+    func test_wal_requiresAnalyze_sanitizedOut() {
+        var opts = ExplainOptions.default
+        opts.wal = true
+        let out = DatabaseType.postgresql.explainSQL(for: sql, options: opts)!
+        XCTAssertFalse(out.contains("WAL"))
+    }
+
+    func test_serialize_requiresAnalyze_sanitizedOut() {
+        var opts = ExplainOptions.default
+        opts.serialize = .text
+        let out = DatabaseType.postgresql.explainSQL(for: sql, options: opts)!
+        XCTAssertFalse(out.contains("SERIALIZE"))
+    }
+
+    func test_canEnable_returnsFalse_whenAnalyzeOff() {
+        var opts = ExplainOptions.default
+        opts.analyze = false
+        for dep in ExplainOptions.AnalyzeDependency.allCases {
+            XCTAssertFalse(opts.canEnable(dep), "\(dep) must be disabled when analyze=false")
+        }
+    }
+
+    func test_canEnable_returnsTrue_whenAnalyzeOn() {
+        var opts = ExplainOptions.default
+        opts.analyze = true
+        for dep in ExplainOptions.AnalyzeDependency.allCases {
+            XCTAssertTrue(opts.canEnable(dep), "\(dep) must be enabled when analyze=true")
+        }
+    }
+
+    func test_analyzeOn_keepsDependentOptions() {
+        var opts = ExplainOptions.default
+        opts.analyze = true
+        opts.timing = true
+        opts.wal = true
+        opts.serialize = .binary
+        let out = DatabaseType.postgresql.explainSQL(for: sql, options: opts)!
+        XCTAssertTrue(out.contains("ANALYZE true"))
+        XCTAssertTrue(out.contains("TIMING true"))
+        XCTAssertTrue(out.contains("WAL true"))
+        XCTAssertTrue(out.contains("SERIALIZE BINARY"))
+    }
+
+    // MARK: - Format submenu
+
+    func test_format_changesOutputClause() {
+        for fmt in ExplainOptions.Format.allCases {
+            var opts = ExplainOptions.default
+            opts.format = fmt
+            let out = DatabaseType.postgresql.explainSQL(for: sql, options: opts)!
+            XCTAssertTrue(out.contains("FORMAT \(fmt.rawValue)"),
+                          "missing 'FORMAT \(fmt.rawValue)' in: \(out)")
+        }
+    }
+
+    // MARK: - Version gating
+
+    func test_versionGating_minMajor() {
+        XCTAssertEqual(ExplainOptions.VersionGated.settings.minPostgresMajor,    12)
+        XCTAssertEqual(ExplainOptions.VersionGated.wal.minPostgresMajor,         13)
+        XCTAssertEqual(ExplainOptions.VersionGated.genericPlan.minPostgresMajor, 16)
+        XCTAssertEqual(ExplainOptions.VersionGated.memory.minPostgresMajor,      17)
+        XCTAssertEqual(ExplainOptions.VersionGated.serialize.minPostgresMajor,   17)
+    }
+
+    func test_isAvailable_respectsServerVersion() {
+        // PG 12 server: settings yes, wal/generic/memory/serialize no.
+        XCTAssertTrue(ExplainOptions.isAvailable(.settings, on: 12))
+        XCTAssertFalse(ExplainOptions.isAvailable(.wal, on: 12))
+        XCTAssertFalse(ExplainOptions.isAvailable(.memory, on: 12))
+
+        // PG 17 server: every gated option allowed.
+        for opt in ExplainOptions.VersionGated.allCases {
+            XCTAssertTrue(ExplainOptions.isAvailable(opt, on: 17),
+                          "\(opt) must be available on PG 17")
+        }
+    }
+
+    func test_isAvailable_nilVersion_permitsEverything() {
+        // When server version is unknown, we default to permissive — let the
+        // server tell the user. Matches the rest of the codebase, which doesn't
+        // pre-detect server features.
+        for opt in ExplainOptions.VersionGated.allCases {
+            XCTAssertTrue(ExplainOptions.isAvailable(opt, on: nil))
+        }
+    }
+
+    // MARK: - Other engines unchanged by options
+
+    func test_otherEngines_ignoreOptions() {
+        var opts = ExplainOptions.default
+        opts.analyze = true
+        opts.buffers = true
+        opts.format  = .json
+        // MySQL / SQLite / MSSQL / ClickHouse have no per-option syntax.
+        XCTAssertEqual(DatabaseType.mysql.explainSQL(for: sql, options: opts),
+                       "EXPLAIN \(sql)")
+        XCTAssertEqual(DatabaseType.sqlite.explainSQL(for: sql, options: opts),
+                       "EXPLAIN QUERY PLAN \(sql)")
+        XCTAssertEqual(DatabaseType.mssql.explainSQL(for: sql, options: opts),
+                       "SET SHOWPLAN_TEXT ON; \(sql); SET SHOWPLAN_TEXT OFF")
+        XCTAssertEqual(DatabaseType.clickhouse.explainSQL(for: sql, options: opts),
+                       "EXPLAIN \(sql)")
+        XCTAssertNil(DatabaseType.mongodb.explainSQL(for: sql, options: opts))
+        XCTAssertNil(DatabaseType.redis.explainSQL(for: sql, options: opts))
+    }
+
+    // MARK: - Codable persistence
+
+    func test_codable_roundTripsAllFields() throws {
+        var opts = ExplainOptions.default
+        opts.analyze     = true
+        opts.buffers     = true
+        opts.genericPlan = true
+        opts.memory      = true
+        opts.settings    = true
+        opts.summary     = true
+        opts.timing      = true
+        opts.verbose     = true
+        opts.wal         = true
+        opts.serialize   = .binary
+        opts.format      = .json
+
+        let data = try JSONEncoder().encode(opts)
+        let restored = try JSONDecoder().decode(ExplainOptions.self, from: data)
+        XCTAssertEqual(restored, opts)
+    }
+
+    // MARK: - PG version banner parsing
+
+    func test_parsePostgresMajor_examples() {
+        XCTAssertEqual(QueryEditorView.parsePostgresMajor(from:
+            "PostgreSQL 16.2 on aarch64-apple-darwin"), 16)
+        XCTAssertEqual(QueryEditorView.parsePostgresMajor(from:
+            "PostgreSQL 9.6.24 on x86_64-pc-linux-gnu"), 9)
+        XCTAssertEqual(QueryEditorView.parsePostgresMajor(from:
+            "PostgreSQL 17rc1"), 17)
+        XCTAssertNil(QueryEditorView.parsePostgresMajor(from: "garbage"))
+        XCTAssertNil(QueryEditorView.parsePostgresMajor(from: ""))
+    }
+}

--- a/macos/Tests/GridexTests/ExplainOptionsTests.swift
+++ b/macos/Tests/GridexTests/ExplainOptionsTests.swift
@@ -198,6 +198,50 @@ final class ExplainOptionsTests: XCTestCase {
         XCTAssertEqual(restored, opts)
     }
 
+    // MARK: - Profile preset
+
+    func test_profilePreset_setsTheRightFourFlags() {
+        let preset = ExplainOptions.profilePreset(currentFormat: .text)
+        XCTAssertTrue(preset.analyze, "ANALYZE — actual times require it")
+        XCTAssertTrue(preset.buffers, "BUFFERS — cache hit/read stats")
+        XCTAssertTrue(preset.verbose, "VERBOSE — schema-qualified output")
+        XCTAssertTrue(preset.summary, "SUMMARY — planning + execution time")
+    }
+
+    func test_profilePreset_doesNotSetUnrelatedFlags() {
+        // Memory / Generic Plan / Settings / Timing / WAL / Serialize are
+        // problem-specific. Default preset must not over-commit — leaves
+        // them off so the user can layer them in if needed.
+        let preset = ExplainOptions.profilePreset(currentFormat: .text)
+        XCTAssertFalse(preset.memory)
+        XCTAssertFalse(preset.genericPlan)
+        XCTAssertFalse(preset.settings)
+        XCTAssertFalse(preset.timing)
+        XCTAssertFalse(preset.wal)
+        XCTAssertEqual(preset.serialize, .off)
+    }
+
+    func test_profilePreset_keepsCurrentFormat() {
+        // User on Tree view (FORMAT JSON) clicking the preset must NOT get
+        // bumped back to TEXT — that would silently switch their view mode.
+        for format in ExplainOptions.Format.allCases {
+            let preset = ExplainOptions.profilePreset(currentFormat: format)
+            XCTAssertEqual(preset.format, format,
+                "preset must preserve user's chosen format \(format)")
+        }
+    }
+
+    func test_profilePreset_buildsValidPGOptionList() {
+        // Sanity: the preset must produce a valid `EXPLAIN (...)` shape that
+        // includes ANALYZE true / BUFFERS true / VERBOSE true / SUMMARY true.
+        let preset = ExplainOptions.profilePreset(currentFormat: .json)
+        let sql = DatabaseType.postgresql.explainSQL(for: "SELECT 1", options: preset)!
+        for piece in ["ANALYZE true", "BUFFERS true", "VERBOSE true",
+                      "SUMMARY true", "FORMAT JSON"] {
+            XCTAssertTrue(sql.contains(piece), "preset SQL missing '\(piece)': \(sql)")
+        }
+    }
+
     // MARK: - PG version banner parsing
 
     func test_parsePostgresMajor_examples() {

--- a/macos/Tests/GridexTests/ExplainOutputViewTests.swift
+++ b/macos/Tests/GridexTests/ExplainOutputViewTests.swift
@@ -1,0 +1,206 @@
+// ExplainOutputViewTests.swift
+// Pure-logic tests for the OSS-side EXPLAIN output renderer:
+// the JSON pretty-printer and the read-only plan tree walker.
+//
+// We deliberately don't test the SwiftUI views — that's what manual UI test
+// plan is for. These tests pin the data-shape contract so the views can't
+// silently misbehave when JSON shapes change.
+
+import XCTest
+@testable import Gridex
+
+final class ExplainOutputViewTests: XCTestCase {
+
+    // MARK: - JSON pretty printer
+
+    func test_prettyPrint_minifiedJSON_isReformatted() {
+        let raw = #"[{"Plan":{"Node Type":"Seq Scan","Total Cost":42.0}}]"#
+        let pretty = ExplainJSONPrettyPrinter.prettyPrint(raw)
+        XCTAssertNotNil(pretty)
+        // Pretty output adds newlines + indentation.
+        XCTAssertTrue(pretty!.contains("\n"))
+        XCTAssertTrue(pretty!.contains("Node Type"))
+        XCTAssertTrue(pretty!.contains("Seq Scan"))
+    }
+
+    func test_prettyPrint_invalidJSON_returnsNil() {
+        XCTAssertNil(ExplainJSONPrettyPrinter.prettyPrint("not json"))
+        XCTAssertNil(ExplainJSONPrettyPrinter.prettyPrint(""))
+        XCTAssertNil(ExplainJSONPrettyPrinter.prettyPrint("{ unclosed"))
+    }
+
+    func test_prettyPrint_sortedKeys_isStable() {
+        // Two semantically identical inputs with different key order must
+        // produce the same pretty output (`.sortedKeys` enabled).
+        let a = #"{"b":2,"a":1}"#
+        let b = #"{"a":1,"b":2}"#
+        XCTAssertEqual(ExplainJSONPrettyPrinter.prettyPrint(a),
+                       ExplainJSONPrettyPrinter.prettyPrint(b))
+    }
+
+    // MARK: - Plan reader — happy path
+
+    func test_planReader_parses_singleNodePlan() {
+        let json = """
+        [{
+            "Plan": {
+                "Node Type": "Seq Scan",
+                "Startup Cost": 0.0,
+                "Total Cost": 22.0,
+                "Plan Rows": 1000,
+                "Plan Width": 64,
+                "Relation Name": "profile"
+            }
+        }]
+        """
+        let nodes = ExplainPlanReader.parse(jsonString: json)
+        XCTAssertNotNil(nodes)
+        XCTAssertEqual(nodes?.count, 1)
+
+        let root = nodes![0]
+        XCTAssertEqual(root.nodeType, "Seq Scan")
+        XCTAssertTrue(root.summary.contains("cost=0.00..22.00"),
+                      "summary must include startup..total cost; got '\(root.summary)'")
+        XCTAssertTrue(root.summary.contains("rows=1000"))
+        XCTAssertTrue(root.summary.contains("width=64"))
+        XCTAssertEqual(root.children.count, 0)
+
+        // Relation Name must surface as an attribute (browseable but not parsed).
+        XCTAssertTrue(root.attributes.contains { $0.0 == "Relation Name" && $0.1 == "profile" })
+    }
+
+    func test_planReader_walksNestedPlans() {
+        let json = """
+        [{
+            "Plan": {
+                "Node Type": "Hash Join",
+                "Total Cost": 100.0,
+                "Plans": [
+                    { "Node Type": "Seq Scan", "Total Cost": 50.0 },
+                    {
+                        "Node Type": "Hash",
+                        "Total Cost": 30.0,
+                        "Plans": [
+                            { "Node Type": "Index Scan", "Total Cost": 5.0 }
+                        ]
+                    }
+                ]
+            }
+        }]
+        """
+        let nodes = ExplainPlanReader.parse(jsonString: json)!
+        XCTAssertEqual(nodes.count, 1)
+
+        let root = nodes[0]
+        XCTAssertEqual(root.nodeType, "Hash Join")
+        XCTAssertEqual(root.children.count, 2)
+        XCTAssertEqual(root.children[0].nodeType, "Seq Scan")
+        XCTAssertEqual(root.children[1].nodeType, "Hash")
+        XCTAssertEqual(root.children[1].children.count, 1)
+        XCTAssertEqual(root.children[1].children[0].nodeType, "Index Scan")
+    }
+
+    func test_planReader_excludesCostAndPlanKeys_fromAttributes() {
+        // The summary line already shows cost / rows / width and children are
+        // walked separately via Plans. Those keys must NOT appear in the
+        // browseable attributes list — that would create duplicate noise.
+        let json = """
+        [{ "Plan": {
+            "Node Type": "Seq Scan",
+            "Startup Cost": 0.0, "Total Cost": 22.0,
+            "Plan Rows": 1, "Plan Width": 32,
+            "Plans": []
+        }}]
+        """
+        let attrs = ExplainPlanReader.parse(jsonString: json)![0].attributes
+        let keys = Set(attrs.map(\.0))
+        XCTAssertFalse(keys.contains("Plans"))
+        XCTAssertFalse(keys.contains("Node Type"))
+        XCTAssertFalse(keys.contains("Startup Cost"))
+        XCTAssertFalse(keys.contains("Total Cost"))
+        XCTAssertFalse(keys.contains("Plan Rows"))
+        XCTAssertFalse(keys.contains("Plan Width"))
+    }
+
+    func test_planReader_attributesAreSorted() {
+        // Stable sort lets snapshot tests + UI rendering be deterministic.
+        let json = """
+        [{ "Plan": {
+            "Node Type": "Index Scan",
+            "Total Cost": 1.0,
+            "Z Field": "z",
+            "A Field": "a",
+            "M Field": "m"
+        }}]
+        """
+        let keys = ExplainPlanReader.parse(jsonString: json)![0].attributes.map(\.0)
+        XCTAssertEqual(keys, keys.sorted())
+    }
+
+    // MARK: - Plan reader — error paths
+
+    func test_planReader_returnsNil_onNonJSON() {
+        XCTAssertNil(ExplainPlanReader.parse(jsonString: "Seq Scan on profile  (cost=0.00..22.00 rows=1000 width=64)"))
+    }
+
+    func test_planReader_returnsNil_onJSONWithoutPlanKey() {
+        // Valid JSON but doesn't match the EXPLAIN shape.
+        XCTAssertNil(ExplainPlanReader.parse(jsonString: #"[{"foo":"bar"}]"#))
+        XCTAssertNil(ExplainPlanReader.parse(jsonString: "{}"))
+        XCTAssertNil(ExplainPlanReader.parse(jsonString: "[]"))
+    }
+
+    func test_planReader_returnsNil_onEmptyString() {
+        XCTAssertNil(ExplainPlanReader.parse(jsonString: ""))
+    }
+
+    // MARK: - Real PG output shape
+
+    func test_planReader_handlesRealishPostgresOutput() {
+        // Trimmed but representative of `EXPLAIN (FORMAT JSON, ANALYZE)`
+        // output from PG 16. Contains every key shape the renderer cares
+        // about: nested Plans, mixed primitive types, optional fields.
+        let json = """
+        [
+          {
+            "Plan": {
+              "Node Type": "Hash Right Join",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Join Type": "Right",
+              "Startup Cost": 2264.43,
+              "Total Cost": 2369.01,
+              "Plan Rows": 290,
+              "Plan Width": 358,
+              "Actual Startup Time": 0.085,
+              "Actual Total Time": 61.929,
+              "Actual Rows": 3378,
+              "Actual Loops": 1,
+              "Hash Cond": "(p.id = u.profile_id)",
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Total Cost": 100.0,
+                  "Plan Rows": 5000,
+                  "Plan Width": 32,
+                  "Relation Name": "users"
+                }
+              ]
+            },
+            "Planning Time": 0.123,
+            "Execution Time": 62.1
+          }
+        ]
+        """
+        let nodes = ExplainPlanReader.parse(jsonString: json)
+        XCTAssertNotNil(nodes)
+        XCTAssertEqual(nodes?.count, 1)
+        XCTAssertEqual(nodes?[0].nodeType, "Hash Right Join")
+        XCTAssertEqual(nodes?[0].children.count, 1)
+        XCTAssertEqual(nodes?[0].children[0].nodeType, "Seq Scan")
+        // Booleans surface as "true"/"false" string attributes.
+        let parallel = nodes?[0].attributes.first { $0.0 == "Parallel Aware" }
+        XCTAssertEqual(parallel?.1, "false")
+    }
+}

--- a/macos/Tests/GridexTests/PostgreSQLAdapterIntegrationTests.swift
+++ b/macos/Tests/GridexTests/PostgreSQLAdapterIntegrationTests.swift
@@ -346,4 +346,62 @@ final class PostgreSQLAdapterIntegrationTests: XCTestCase {
         _ = try? await adapter.executeRaw(sql: "DROP TABLE IF EXISTS \(table)")
         try await adapter.disconnect()
     }
+
+    // MARK: - ExplainOptions — server accepts the option lists we build
+
+    /// Sanity check that `EXPLAIN (BUFFERS true, COSTS true, FORMAT JSON, ...)`
+    /// — the shape produced when a user toggles options in the new dropdown —
+    /// is something a real PG server actually parses. The pure-logic
+    /// ExplainOptionsTests cover SQL shape; this one covers wire compatibility.
+    func test_explainOptions_pgAcceptsBuiltOptionLists() async throws {
+        try skipIfNoServer(port: 55434)
+
+        let cfg = makeBaseConfig(host: "127.0.0.1", port: 55434, sslMode: .disabled)
+        let adapter = PostgreSQLAdapter()
+        try await adapter.connect(config: cfg, password: nil)
+
+        let table = "gridex_explain_opts_\(UUID().uuidString.prefix(8).lowercased())"
+        do {
+            _ = try await adapter.executeRaw(sql: "CREATE TABLE \(table) (id int)")
+            _ = try await adapter.executeRaw(sql: "INSERT INTO \(table) VALUES (1), (2), (3)")
+
+            // Plan-only with extra detail — should never modify data.
+            var planOnly = ExplainOptions.default
+            planOnly.buffers = true
+            planOnly.verbose = true
+            planOnly.summary = true
+            planOnly.format  = .json
+            let planSQL = DatabaseType.postgresql.explainSQL(
+                for: "SELECT * FROM \(table)",
+                options: planOnly
+            )!
+            let planRes = try await adapter.executeRaw(sql: planSQL)
+            XCTAssertFalse(planRes.rows.isEmpty,
+                "EXPLAIN with bool toggles + JSON format must return plan rows")
+
+            // Actual execution with timing — should run the SELECT, not modify
+            // the table. Asserts the cross-disable rules in `sanitized()` don't
+            // strip Timing when ANALYZE is on.
+            var withAnalyze = ExplainOptions.default
+            withAnalyze.analyze = true
+            withAnalyze.timing  = true
+            withAnalyze.buffers = true
+            let analyzeSQL = DatabaseType.postgresql.explainSQL(
+                for: "SELECT count(*) FROM \(table)",
+                options: withAnalyze
+            )!
+            XCTAssertTrue(analyzeSQL.contains("TIMING true"),
+                "Timing must survive sanitize when Analyze is on")
+            let analyzeRes = try await adapter.executeRaw(sql: analyzeSQL)
+            XCTAssertFalse(analyzeRes.rows.isEmpty,
+                "EXPLAIN ANALYZE must return plan rows including actual times")
+        } catch {
+            _ = try? await adapter.executeRaw(sql: "DROP TABLE IF EXISTS \(table)")
+            try? await adapter.disconnect()
+            throw error
+        }
+
+        _ = try? await adapter.executeRaw(sql: "DROP TABLE IF EXISTS \(table)")
+        try await adapter.disconnect()
+    }
 }


### PR DESCRIPTION
Adds a dropdown next to the query editor's Explain button surfacing every Postgres EXPLAIN toggle a DBA actually wants. Inspired by pgAdmin4's panel; per-connection options are persisted across sessions.

## What you get

| | |
|---|---|
| **Top-level toggle** | **Analyze (execute query)** — load-bearing, decides plan-only vs measure-actual |
| **Plain bool toggles** | Buffers · Costs (default on) · Generic Plan · Memory · Settings · Summary · Timing · Verbose · WAL |
| **Submenu — Format** | TEXT / JSON / YAML / XML |
| **Submenu — Serialize** | Off / NONE / TEXT / BINARY |
| **Visible only on** | PostgreSQL connections — other engines have no option list, so the chevron disappears |

## Smart UX rules baked in

- **Cross-disable**: Timing / WAL / Serialize are greyed unless Analyze is on (PG would 400 otherwise).
- **Version gating**: Settings (PG 12+), WAL (PG 13+), Generic Plan (PG 16+), Memory + Serialize (PG 17+). Detected from `version()` banner — older servers see those rows greyed with a `(PG NN+)` hint.
- **Pre-flight sanitize**: `ExplainOptions.sanitized()` strips ANALYZE-dependent flags before sending, so the server never sees an option list it would reject.
- **Per-connection persistence**: chosen options survive app restart (UserDefaults keyed by connection UUID), so a fix made on one server doesn't pollute a sibling.

## Architecture

```
Core/Models/Query/ExplainOptions.swift           ← struct + enums + rules
Core/Extensions/DatabaseType+Explain.swift       ← refactor: accepts options, default is byte-equivalent to legacy
Presentation/Views/QueryEditor/Explain/
  └─ ExplainOptionsMenu.swift                    ← SwiftUI menu (chevron beside Explain button)
Presentation/Views/QueryEditor/QueryEditorView.swift  ← split-button + load/persist + version probe
Tests/GridexTests/ExplainOptionsTests.swift      ← 17 new pure-logic tests
Tests/GridexTests/PostgreSQLAdapterIntegrationTests.swift  ← +1 wire-compat test
```

## Tests

29 explain-related tests pass:
- 10 existing `DatabaseTypeExplainTests` (default param preserves legacy byte-for-byte)
- 17 new `ExplainOptionsTests` — toggle matrix, cross-disable, version gating, Codable round-trip, banner parser
- 2 PG integration vs `:55434` — `BUFFERS+VERBOSE+SUMMARY+JSON` returns plan rows; `ANALYZE+TIMING+BUFFERS` returns actual-time rows

```
swift test --filter "ExplainOptions|DatabaseTypeExplain|test_explainOptions_pgAccepts|test_explainSQL_postgresShape"
…
Executed 29 tests, with 0 failures (0 unexpected) in 0.082s
```

## Risk

Low. The refactored `explainSQL(for:options:)` keeps a default value byte-identical to the previous hardcoded shape — every existing call site (MCP `explain_query` tool, the regular Explain button when no toggles are tweaked) sends the exact same SQL it did on `main`. New behaviour activates only when the user opens the new menu.

## Out of scope (intentionally)

- **Visual plan-tree rendering** for `FORMAT JSON` output. The output panel shows raw text/JSON. Tree rendering + slow-node heuristics + recommendation cards live separately as an Enterprise Edition feature; this PR's clean text + per-option toggles is the OSS surface that EE will read on top of.
- **MySQL `EXPLAIN FORMAT=JSON|TREE`** and other engines' option flavours. When that arrives, extend `ExplainOptions` with engine-specific sub-types or per-engine builder methods. Current PR keeps the public API single-engine-aware (PG) and gracefully no-ops elsewhere.

## Test plan

- [x] `swift build` clean
- [x] `swift test` for the explain families — 29 / 29 green
- [x] PG :55434 wire compatibility for the new option lists
- [ ] Manual UI: connect to PG → click Explain → toggle Buffers + JSON → verify SQL hits server, output appears in panel
- [ ] Manual UI: toggle Analyze + Timing → click Explain → verify actual-time numbers in plan
- [ ] Manual UI: connect to PG 12 → menu shows Memory / Generic Plan greyed with `(PG NN+)` hint
- [ ] Manual UI: switch active connection → verify options reload from per-connection UserDefaults
- [ ] Manual UI: connect to MySQL → verify chevron is hidden, plain Explain still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)