### PR TITLE
chore(release): bump version to 0.0.17

### DIFF
--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -32,9 +32,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.16</string>
+	<string>0.0.17</string>
 	<key>CFBundleVersion</key>
-	<string>16</string>
+	<string>17</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Folds in the rich Explain output panel (Text/JSON/Tree views) and the Profile preset + Analyze hint banner — onboarding nudges so users clicking Explain without ticking ANALYZE see a clear path to actual times and cache stats.