### PR TITLE
chore(release): bump Linux version to 0.2.0

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(gridex
-    VERSION 0.1.0
+    VERSION 0.2.0
     DESCRIPTION "Gridex — AI-Native Database IDE (Linux)"
     LANGUAGES CXX
 )


### PR DESCRIPTION
## Summary
Cuts the second Linux release. Artefacts uploaded to R2:

- \`https://cdn.gridex.app/linux/Gridex-0.2.0-x86_64.AppImage\`
- \`https://cdn.gridex.app/linux/releases.stable.json\`

\`\`\`
SHA256: 535771160d172973c6042b65ed06ab582a664847eea3bf32365cddc4d4e1009f
Size:   41011704 bytes (~40 MB)
\`\`\`

## What's new since 0.1.0
- **Sign in with ChatGPT** — PKCE OAuth flow against the public Codex CLI \`client_id\`, token refresh, libsecret-backed bundle persistence, full \`ChatGPTProvider\` hitting \`chatgpt.com/backend-api/codex/responses\` (#60).
- **ClickHouse adapter** via the HTTP interface — JSONCompact parsing, \`USE\`-statement intercept, engine-aware \`ALTER TABLE UPDATE/DELETE\` guards (#59).
- **AppImage auto-update** via R2-hosted \`releases.stable.json\` — silent startup check + \`Help → Check for Updates\` dialog with self-replace + restart on existing AppImage runs.
- **MCP polish** — JSON-RPC notifications no longer get a response, Setup tab now lists Linux-correct paths for Claude Code, Cursor, Windsurf, and Gemini CLI.

## Test plan
- [x] R2 feed parses, AppImage downloads with 200 + correct content-type.
- [x] Existing 0.1.0 AppImage installs sees the update banner and self-replaces on click.
- [x] Fresh \`./Gridex-0.2.0-x86_64.AppImage\` boot — sign in with ChatGPT, send a chat, run a ClickHouse query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)