### PR TITLE
fix(mcp): stub unimplemented capability handlers & auto-connect on stdio startup

### DIFF
--- a/macos/App/Lifecycle/main.swift
+++ b/macos/App/Lifecycle/main.swift
@@ -50,6 +50,7 @@ func runMCPServerAsync(modelContainer: ModelContainer) async {
     // Create services
     let connectionManager = ConnectionManager()
     let connectionRepository = SwiftDataConnectionRepository(modelContainer: modelContainer)
+    let keychain = KeychainService()
 
     // Create MCP server with stdio transport for CLI mode
     let mcpServer = MCPServer(
@@ -59,11 +60,28 @@ func runMCPServerAsync(modelContainer: ModelContainer) async {
         transportMode: .stdio
     )
 
-    // Load connections and their MCP modes
+    // Load connections, register their MCP modes, and pre-open DB connections so
+    // tools that require an active adapter (list_tables, query, …) work without
+    // requiring the GUI app to be open. The stdio entrypoint runs in a separate
+    // process from the main GUI, so it cannot share live adapters with it.
     do {
         let configs = try await connectionRepository.fetchAll()
         for config in configs where config.mcpMode != .locked {
             await mcpServer.setConnectionMode(config.mcpMode, for: config.id)
+
+            let password = (try? keychain.loadPassword(connectionId: config.id)) ?? nil
+            let sshPassword = config.sshConfig != nil
+                ? ((try? keychain.loadSSHPassword(connectionId: config.id)) ?? nil)
+                : nil
+            do {
+                _ = try await connectionManager.connect(
+                    config: config,
+                    password: password,
+                    sshPassword: sshPassword
+                )
+            } catch {
+                fputs("Warning: Failed to open connection '\(config.name)': \(error)\n", stderr)
+            }
         }
     } catch {
         fputs("Warning: Failed to load connections: \(error)\n", stderr)

--- a/macos/Services/MCP/MCPServer.swift
+++ b/macos/Services/MCP/MCPServer.swift
@@ -93,7 +93,7 @@ actor MCPServer: StdioTransportDelegate {
         case "initialize":
             response = await handleInitialize(request)
 
-        case "initialized":
+        case "initialized", "notifications/initialized":
             // Client acknowledges initialization, no response needed
             return
 
@@ -102,6 +102,15 @@ actor MCPServer: StdioTransportDelegate {
 
         case "tools/call":
             response = await handleToolCall(request)
+
+        case "prompts/list":
+            response = JSONRPCResponse(id: request.id, result: .object(["prompts": .array([])]))
+
+        case "resources/list":
+            response = JSONRPCResponse(id: request.id, result: .object(["resources": .array([])]))
+
+        case "resources/templates/list":
+            response = JSONRPCResponse(id: request.id, result: .object(["resourceTemplates": .array([])]))
 
         case "ping":
             response = JSONRPCResponse(id: request.id, result: .object(["pong": .bool(true)]))


### PR DESCRIPTION
## Summary

The macOS MCP stdio server is currently broken for spec-strict clients like Claude Code. Two distinct bugs combine so that tools never actually run end-to-end:

1. **`initialize` advertises capabilities the dispatcher does not handle.** `prompts`, `resources` (with `subscribe`), and `resources.listChanged` are all set to `true` in the `InitializeResult`, but `MCPServer.handleRequest` has no case for `prompts/list`, `resources/list`, or `resources/templates/list`. They fall through to the default branch and return `-32601 Method not found`. Claude Code treats unimplemented declared-capability methods as a fatal protocol error and tears the stdio pipe down immediately after init — so even `tools/list`, which works perfectly, becomes unreachable from the client's POV.
2. **Stdio mode never opens DB connections.** `runMCPServerAsync` builds a fresh `ConnectionManager`, calls `connectionRepository.fetchAll()` only to register MCP modes, and starts the server. Because `--mcp-stdio` runs in a separate process from the GUI, no live adapters are inherited. Any tool routed through `MCPToolContext.getAdapter` (`list_tables`, `query`, `get_sample_rows`, `list_relationships`, `describe_table`, `list_schemas`, `explain_query`, all Tier-3 writes) returns `Connection '<uuid>' not found.` even though `list_connections` reports the config as available.

## Changes

- `macos/Services/MCP/MCPServer.swift`
  - Handle `prompts/list` → `{"prompts": []}`
  - Handle `resources/list` → `{"resources": []}`
  - Handle `resources/templates/list` → `{"resourceTemplates": []}`
  - Accept both `initialized` and `notifications/initialized` (the spec uses the namespaced form; some clients still send the bare form).
- `macos/App/Lifecycle/main.swift`
  - In stdio mode, instantiate a `KeychainService` and, for every non-locked connection, load `db.password.<uuid>` (and `ssh.password.<uuid>` when an SSH config is present) and call `connectionManager.connect(...)`.
  - Failures are logged to stderr but do not block server startup, so a single bad-password connection does not prevent the others from being reachable.

The empty-array stubs preserve the advertised capabilities so existing clients keep their behavior; if `prompts` / `resources` are intended to remain unimplemented, the alternative would be removing them from the capabilities object — happy to switch to that approach if you prefer.

## Test plan

- [x] Probe directly via stdio: `initialize` + `notifications/initialized` + `prompts/list` + `resources/list` + `resources/templates/list` + `tools/list` — all return success on the new build.
- [x] Real Claude Code (2.1.118) handshake — server stays connected, all 13 tools surfaced.
- [x] `list_connections` reports `is_connected: true` immediately after Claude Code spawns the stdio process (no GUI interaction needed).
- [x] `list_schemas`, `list_tables`, and a parameterless `query` execute end-to-end against a live PostgreSQL 16 DB.
- [ ] Verified only against PostgreSQL on macOS arm64 (15.7.5). MySQL / SQLite / Redis / MongoDB / MSSQL paths share the same `connectionManager.connect` entrypoint, so they should benefit identically, but I have not exercised them locally.

## Notes for reviewers

- I left `subscribe: true` in `resources` capabilities untouched. With an empty `resources/list`, no client should ever call `resources/subscribe`, but if you'd rather have it advertised honestly we can drop it.
- `--mcp-stdio` previously assumed connections would be opened "out of band". After this PR each stdio process opens its own adapters; that means it pays the cost of a real `connect()` per process spawn, but that's the only way the MCP tools can actually function without the GUI also being running.