### PR TITLE
ci: add Swift package caching to macOS build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
           swift --version
           xcodebuild -version
 
+      - name: Cache Swift packages
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Resolve dependencies
         run: swift package resolve
 


### PR DESCRIPTION
Cache Swift packages between CI runs to speed up 'swift package resolve'.
Uses actions/cache@v4 with Package.resolved hash as cache key for
proper invalidation when dependencies change.
