### PR TITLE
[codex] Fix PostgreSQL array cell decoding

### DIFF
--- a/macos/Data/Adapters/PostgreSQL/PostgreSQLAdapter.swift
+++ b/macos/Data/Adapters/PostgreSQL/PostgreSQLAdapter.swift
@@ -865,6 +865,22 @@ final class PostgreSQLAdapter: DatabaseAdapter, SchemaInspectable, @unchecked Se
                 return .uuid(try cell.decode(UUID.self))
             case .json, .jsonb:
                 return .json(try cell.decode(String.self))
+            case .textArray, .varcharArray, .bpcharArray, .nameArray:
+                return .array(try cell.decode([String].self).map { .string($0) })
+            case .boolArray:
+                return .array(try cell.decode([Bool].self).map { .boolean($0) })
+            case .int2Array:
+                return .array(try cell.decode([Int16].self).map { .integer(Int64($0)) })
+            case .int4Array:
+                return .array(try cell.decode([Int32].self).map { .integer(Int64($0)) })
+            case .int8Array:
+                return .array(try cell.decode([Int64].self).map { .integer($0) })
+            case .float4Array:
+                return .array(try cell.decode([Float].self).map { .double(Double($0)) })
+            case .float8Array:
+                return .array(try cell.decode([Double].self).map { .double($0) })
+            case .uuidArray:
+                return .array(try cell.decode([UUID].self).map { .uuid($0) })
             default:
                 // Try String decoding, but validate it's not binary garbage
                 if let s = try? cell.decode(String.self),

--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -32,9 +32,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.18</string>
+	<string>0.0.19</string>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAppTransportSecurity</key>

--- a/macos/Tests/GridexTests/PostgreSQLAdapterIntegrationTests.swift
+++ b/macos/Tests/GridexTests/PostgreSQLAdapterIntegrationTests.swift
@@ -307,6 +307,52 @@ final class PostgreSQLAdapterIntegrationTests: XCTestCase {
         try await adapter.disconnect()
     }
 
+    // MARK: - Issue #75 - PostgreSQL array cells must not render as NULL
+
+    func test_execute_decodesTextArrayCells() async throws {
+        try skipIfNoServer(port: 55434)
+
+        let cfg = makeBaseConfig(host: "127.0.0.1", port: 55434, sslMode: .disabled)
+        let adapter = PostgreSQLAdapter()
+        try await adapter.connect(config: cfg, password: nil)
+
+        let table = "gridex_array_test_\(UUID().uuidString.prefix(8).lowercased())"
+        do {
+            _ = try await adapter.executeRaw(sql: "CREATE TEMP TABLE \(table) (id int, reasons text[])")
+            _ = try await adapter.executeRaw(sql: """
+                INSERT INTO \(table) VALUES
+                (1, ARRAY['because', 'why']::text[]),
+                (2, NULL),
+                (3, ARRAY[]::text[])
+                """)
+
+            let result = try await adapter.executeRaw(sql: "SELECT reasons FROM \(table) ORDER BY id")
+
+            XCTAssertEqual(result.rows.count, 3)
+            XCTAssertEqual(result.columns.first?.dataType, "TEXT[]")
+
+            guard case .array(let reasons) = result.rows[0][0] else {
+                XCTFail("Expected non-null text[] to decode as RowValue.array")
+                try? await adapter.disconnect()
+                return
+            }
+            XCTAssertEqual(reasons, [.string("because"), .string("why")])
+            XCTAssertEqual(result.rows[1][0], .null)
+
+            guard case .array(let emptyReasons) = result.rows[2][0] else {
+                XCTFail("Expected empty text[] to decode as an empty RowValue.array")
+                try? await adapter.disconnect()
+                return
+            }
+            XCTAssertTrue(emptyReasons.isEmpty)
+        } catch {
+            try? await adapter.disconnect()
+            throw error
+        }
+
+        try await adapter.disconnect()
+    }
+
     // MARK: - Issue #49 — Explain button server-side regression
 
     // The query editor button used to send "EXPLAIN QUERY PLAN <sql>" to every


### PR DESCRIPTION
## Summary
- Decode PostgreSQL scalar array result cells into `RowValue.array` instead of falling through to `NULL`.
- Cover `text[]` results, including non-empty, NULL, and empty arrays, with an integration regression test for issue #75.
- Bump macOS app version to 0.0.19 in a separate release commit.

## Test Plan
- `git diff --check origin/main...HEAD`
- `swift test --filter PostgreSQLAdapterIntegrationTests` (build passed; PostgreSQL integration cases were skipped because local PG was not reachable on `127.0.0.1:55434` / `127.0.0.1:55435`.)
