### PR TITLE
fix(windows): stabilize MongoDB connect and libssh2 deploy

### DIFF
--- a/windows/Gridex/ConnectionManager.cpp
+++ b/windows/Gridex/ConnectionManager.cpp
@@ -113,10 +113,18 @@ namespace DBModels
         try
         {
             adapter->connect(effectiveConfig, password);
-            auto result = adapter->execute(L"SELECT 1");
-            adapter->disconnect();
-            ok = result.success;
-            if (!ok) outError = result.error;
+            if (config.databaseType == DatabaseType::MongoDB)
+            {
+                adapter->disconnect();
+                ok = true;
+            }
+            else
+            {
+                auto result = adapter->execute(L"SELECT 1");
+                adapter->disconnect();
+                ok = result.success;
+                if (!ok) outError = result.error;
+            }
         }
         catch (const std::exception& e)
         {

--- a/windows/Gridex/Gridex.vcxproj
+++ b/windows/Gridex/Gridex.vcxproj
@@ -286,6 +286,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <DeploymentContent>true</DeploymentContent>
     </Content>
+    <Content Include="C:\vcpkg\installed\x64-windows\debug\bin\libssh2.dll" Condition="'$(Configuration)'=='Debug'">
+      <Link>libssh2.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <DeploymentContent>true</DeploymentContent>
+    </Content>
     <Content Include="C:\vcpkg\installed\x64-windows\debug\bin\utf8proc.dll" Condition="'$(Configuration)'=='Debug'">
       <Link>utf8proc.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/windows/README.md
+++ b/windows/README.md
@@ -20,7 +20,7 @@ Project link các lib native qua vcpkg. Cài 1 lần:
 **Git Bash / MSYS2**:
 ```bash
 /c/vcpkg/vcpkg.exe install \
-  sqlite3 libpq libmariadb openssl hiredis \
+  sqlite3 libpq libmariadb openssl hiredis libssh2 \
   nlohmann-json cpp-httplib \
   --triplet x64-windows
 ```
@@ -28,7 +28,7 @@ Project link các lib native qua vcpkg. Cài 1 lần:
 **PowerShell**:
 ```powershell
 C:\vcpkg\vcpkg.exe install `
-  sqlite3 libpq libmariadb openssl hiredis `
+  sqlite3 libpq libmariadb openssl hiredis libssh2 `
   nlohmann-json cpp-httplib `
   --triplet x64-windows
 ```
@@ -36,7 +36,7 @@ C:\vcpkg\vcpkg.exe install `
 **CMD**:
 ```cmd
 C:\vcpkg\vcpkg.exe install ^
-  sqlite3 libpq libmariadb openssl hiredis ^
+  sqlite3 libpq libmariadb openssl hiredis libssh2 ^
   nlohmann-json cpp-httplib ^
   --triplet x64-windows
 ```


### PR DESCRIPTION
## Summary
- Skip SQL `SELECT 1` probe for MongoDB connect checks; MongoDB adapter already pings during connect.
- Deploy `libssh2.dll` in Debug/AppX output.
- Add `libssh2` to Windows vcpkg setup docs.

## Verification
- MSBuild Debug: passed, 0 errors
- Staged diff secret scan: passed

## Unresolved questions
- None